### PR TITLE
Exposes method to re-fetch authenticated user

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ If there is no authenticated user, the composable will return `null`.
 
 2. `useSanctumAuth`
 
-Composable provides 2 computed properties and 2 methods:
+Composable provides 2 computed properties and 3 methods:
 
 -   `user` - current authenticated user (basically the same as `useSanctumUser`)
 -   `isAuthenticated` - boolean flag indicating whether the user is authenticated or not
 -   `login` - method for logging in the user
 -   `logout` - method for logging out the user
+-   `refreshIdentity` - method for manually re-fetching current authenticated user data
 
 To authenticate a user you should pass credentials payload as an argument to the `login` method. The payload should contain all fields that are required by your Laravel Sanctum backend.
 

--- a/playground/pages/profile.vue
+++ b/playground/pages/profile.vue
@@ -5,10 +5,11 @@ definePageMeta({
     middleware: ['sanctum:auth'],
 });
 
-const { isAuthenticated, user } = useSanctumAuth();
+const { isAuthenticated, user, refreshIdentity } = useSanctumAuth();
 </script>
 
 <template>
     <p>Your authentication status - {{ isAuthenticated }}</p>
     <p>Identity object - {{ user }}</p>
+    <div><button @click="refreshIdentity">Refetch user</button></div>
 </template>

--- a/src/runtime/composables/useSanctumAuth.ts
+++ b/src/runtime/composables/useSanctumAuth.ts
@@ -9,6 +9,7 @@ export interface SanctumAuth<T> {
     isAuthenticated: Ref<boolean>;
     login: (credentials: Record<string, any>) => Promise<void>;
     logout: () => Promise<void>;
+    refreshIdentity: () => Promise<void>;
 }
 
 /**
@@ -97,5 +98,6 @@ export const useSanctumAuth = <T>(): SanctumAuth<T> => {
         isAuthenticated,
         login,
         logout,
+        refreshIdentity,
     } as SanctumAuth<T>;
 };


### PR DESCRIPTION
This PR exposes the `refreshIdentity` method from the `useSanctumAuth` composable. This is useful in cases where one needs to refresh the authenticated user's data. It addresses manchenkoff/nuxt-auth-sanctum#24.