### PR TITLE
Bearer token auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "release": "npm run validate && npm run prepack && changelogen --release && npm publish && git push --follow-tags"
   },
   "dependencies": {
+    "@capacitor/core": "^5.7.1",
+    "@capacitor/preferences": "^5.0.7",
     "@nuxt/kit": "^3.9.0",
     "defu": "^6.1.4"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,8 @@ export default defineNuxtModule<Partial<SanctumModuleOptions>>({
             csrf: '/sanctum/csrf-cookie',
             login: '/login',
             logout: '/logout',
+            loginMobile: '/login/mobile',
+            logoutMobile: '/logout/mobile',
             user: '/api/user',
         },
         csrf: {

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -10,6 +10,8 @@ import {
 import type { SanctumModuleOptions } from '../types';
 import { useSanctumUser } from './composables/useSanctumUser';
 import { useRequestURL } from 'nuxt/app';
+import { Capacitor } from '@capacitor/core';
+import { Preferences } from '@capacitor/preferences';
 
 export const SECURE_METHODS = new Set(['post', 'delete', 'put', 'patch']);
 
@@ -72,9 +74,12 @@ export function createHttpClient(): $Fetch {
         async onRequest({ options }): Promise<void> {
             const method = options.method?.toLowerCase() ?? 'get';
 
+            const authToken = Capacitor.isNativePlatform() && await Preferences.get({ key: 'token' }).value;
+
             options.headers = {
                 Accept: 'application/json',
                 ...options.headers,
+                ...(authToken && { 'Authorization': `Bearer ${authToken}` }),
             };
 
             // https://laravel.com/docs/10.x/routing#form-method-spoofing

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -128,6 +128,12 @@ export function createHttpClient(): $Fetch {
                     return;
                 }
 
+                if (Capacitor.isNativePlatform()) {
+                    await Preferences.remove({
+                        key: 'token',
+                    });
+                }
+
                 user.value = null;
 
                 if (options.redirect.onLogout) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,14 @@ export interface SanctumEndpoints {
      */
     logout: string;
     /**
+     * The endpoint to send user credentials to authenticate.
+     */
+    loginMobile: string;
+    /**
+     * The endpoint to destroy current user session.
+     */
+    logoutMobile: string;
+    /**
      * The endpoint to fetch current user data.
      */
     user: string;


### PR DESCRIPTION
One thing I'm not sure how to do ...
For CapacitorJS, it doesn't seem to find the modules when they are only installed from inside the package.
Probably there is a way to fix that, I'm just not sure how.

In order to use this for now you also need to install the dependencies locally and use `npx cap sync`

To use this you also need to make an endpoint for Mobile Login & Logout

```php
Route::post('/login/mobile', function (\App\Http\Requests\Auth\LoginRequest $request) {
    $request->authenticate();
    $token = $request->user()->createToken(now()->toDateString())->plainTextToken;
    return Response::json(['token' => $token]);
}) ->middleware('guest')->name('login.mobile');

Route::post('/logout/mobile', function (\Illuminate\Http\Request $request) {
    $request->user()->currentAccessToken()->delete();
    return Response::json([]);
})->middleware('auth:sanctum')->name('logout.mobile');
```
