### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -83,11 +83,11 @@ export function createHttpClient(): $Fetch {
                 options.body.append('_method', 'PUT');
             }
 
-            if (process.server) {
+            if (import.meta.server) {
                 options.headers = buildServerHeaders(options.headers);
             }
 
-            if (process.client) {
+            if (import.meta.client) {
                 if (!SECURE_METHODS.has(method)) {
                     return;
                 }
@@ -98,7 +98,7 @@ export function createHttpClient(): $Fetch {
 
         async onResponse({ response }): Promise<void> {
             // pass all cookies from the API to the client on SSR response
-            if (process.server) {
+            if (import.meta.server) {
                 const serverCookieName = 'set-cookie';
                 const cookie = response.headers.get(serverCookieName);
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

**Describe alternatives you've considered**

A clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context or screenshots about the feature request here.

**Checklist:**

-   [ ] Code style and linters are passing
-   [ ] Backwards compatibility is maintained
-   [ ] Requires documentation to be updated
