### PR TITLE
fix: prevent redirect on 401 response from login page

### DIFF
--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -122,7 +122,8 @@ export function createHttpClient(): $Fetch {
 
                 if (
                     options.redirect.onLogout === false ||
-                    options.redirect.onLogout === currentRoute.path
+                    options.redirect.onLogout === currentRoute.path ||
+                    options.redirect.onAuthOnly === currentRoute.path
                 ) {
                     return;
                 }


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Also fixes #44, but in this case, we prevent redirect when for some reason API returns a 401 response when we are on the `login` page.