### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,14 @@ Complete documentation - [Nuxt Auth Sanctum docs](https://manchenkoff.gitbook.io
 npx nuxi@latest module add nuxt-auth-sanctum
 ```
 
-2. Add `nuxt-auth-sanctum` to the `modules` section of `nuxt.config.ts`
+2. Add any required configuration in your `nuxt.config.ts` file
 
 ```js
 export default defineNuxtConfig({
     modules: ['nuxt-auth-sanctum'],
 
-    // nuxt-auth-sanctum options (also configurable via environment variables)
     sanctum: {
         baseUrl: 'http://localhost:80', // Laravel API
-        origin: 'http://localhost:3000', // Nuxt app, by default will be used 'useRequestURL().origin'
     },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -30,14 +30,7 @@ Complete documentation - [Nuxt Auth Sanctum docs](https://manchenkoff.gitbook.io
 1. Add `nuxt-auth-sanctum` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-auth-sanctum
-
-# Using yarn
-yarn add --dev nuxt-auth-sanctum
-
-# Using npm
-npm install --save-dev nuxt-auth-sanctum
+npx nuxi@latest module add nuxt-auth-sanctum
 ```
 
 2. Add `nuxt-auth-sanctum` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
-   [x] Requires documentation to be updated
