### PR TITLE
fix: prevent multiple identity requests on init

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "validate": "npm run fmt:check && npm run lint && npm run types && npm run test",
-    "release": "npm run validate && npm run prepack && changelogen --release && npm publish"
+    "release": "npm run validate && npm run prepack && changelogen --release && npm publish && git push"
   },
   "dependencies": {
     "@nuxt/kit": "^3.9.0",

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -147,7 +147,8 @@ export function createHttpClient(logger: ConsolaInstance): $Fetch {
 
             if (
                 response.status === 401 &&
-                request.toString().endsWith(options.endpoints.user)
+                request.toString().endsWith(options.endpoints.user) &&
+                user.value !== null
             ) {
                 logger.warn(
                     'User session is not set in API or expired, resetting identity'

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,5 +1,5 @@
 import { FetchError } from 'ofetch';
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin, useState } from '#app';
 import { createHttpClient } from './httpFactory';
 import { useSanctumUser } from './composables/useSanctumUser';
 import { useSanctumConfig } from './composables/useSanctumConfig';
@@ -34,7 +34,14 @@ export default defineNuxtPlugin(async () => {
     const logger = createSanctumLogger(options.logLevel);
     const client = createHttpClient(logger);
 
-    if (user.value === null) {
+    const identityFetchedOnInit = useState<boolean>(
+        'sanctum.user.loaded',
+        () => false
+    );
+
+    if (user.value === null && identityFetchedOnInit.value === false) {
+        identityFetchedOnInit.value = true;
+
         try {
             user.value = await client(options.endpoints.user);
         } catch (error) {


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Partially fixes #69, the plugin initialization method was changed in favor of passing the state of the user identity request from the server to the client to prevent another attempt to load the user when we receive 401 on the SSR side.

Also, we reset the plugin user state only when we receive 401 for user retrieval operation and not for other endpoints.

**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
-   [ ] Requires documentation to be updated
