### PR TITLE
fix: experimental support for cloudflare workers

### DIFF
--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -35,6 +35,17 @@ function configureClientInterceptors(
     }
 }
 
+function determineCredentialsMode() {
+    // Fix for Cloudflare workers - https://github.com/cloudflare/workers-sdk/issues/2514
+    const isCredentialsSupported = 'credentials' in Request.prototype;
+
+    if (!isCredentialsSupported) {
+        return undefined;
+    }
+
+    return 'include';
+}
+
 export function createHttpClient(logger: ConsolaInstance): $Fetch {
     const options = useSanctumConfig();
     const user = useSanctumUser();
@@ -53,7 +64,7 @@ export function createHttpClient(logger: ConsolaInstance): $Fetch {
 
     const httpOptions: FetchOptions = {
         baseURL: options.baseUrl,
-        credentials: 'include',
+        credentials: determineCredentialsMode(),
         redirect: 'manual',
         retry: options.client.retry,
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Following up on #6, in this PR we introduce experimental support for Cloudflare workers that do not support `fetch` interface due to missing `credentials` field. 

**Additional context**

Related issue - https://github.com/cloudflare/workers-sdk/issues/2514

**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
