### PR TITLE
fix: use updated csrf token on first login

### DIFF
--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -35,6 +35,17 @@ function configureClientInterceptors(
     }
 }
 
+function determineCredentialsMode() {
+    // Fix for Cloudflare workers - https://github.com/cloudflare/workers-sdk/issues/2514
+    const isCredentialsSupported = 'credentials' in Request.prototype;
+
+    if (!isCredentialsSupported) {
+        return undefined;
+    }
+
+    return 'include';
+}
+
 export function createHttpClient(logger: ConsolaInstance): $Fetch {
     const options = useSanctumConfig();
     const user = useSanctumUser();
@@ -53,7 +64,7 @@ export function createHttpClient(logger: ConsolaInstance): $Fetch {
 
     const httpOptions: FetchOptions = {
         baseURL: options.baseUrl,
-        credentials: 'include',
+        credentials: determineCredentialsMode(),
         redirect: 'manual',
         retry: options.client.retry,
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #108 and probably related #6 (comments from @alecritson). 

Due to the Nuxt hack with the [`runWithContext`](https://nuxt.com/docs/api/composables/use-nuxt-app#runwithcontext) call for request/response interceptors, there was an edge case when cookies after refresh were not included in the result headers due to missing `await` keyword, thus CSRF token was missing or was used from the previous API response.

**Additional context**

This PR changes how the Nuxt instance will be passed to each interceptor. Now each interceptor is wrapped with the current instance context instead of running a loop with one instance.

**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
-   [x] Documentation is updated
