### PR TITLE
feat: configure redirect if unauthenticated

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ export const defaultModuleOptions: Partial<SanctumModuleOptions> = {
     mode: 'cookie',
     userStateKey: 'sanctum.user.identity',
     redirectIfAuthenticated: false,
+    redirectIfUnauthenticated: false,
     endpoints: {
         csrf: '/sanctum/csrf-cookie',
         login: '/login',

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -124,10 +124,15 @@ export interface SanctumModuleOptions {
      */
     userStateKey: string;
     /**
-     * Determine to redirect when user is authenticated.
+     * Determine whether to redirect when the user is authenticated when on login attempt.
      * @default false
      */
     redirectIfAuthenticated: boolean;
+    /**
+     * Determine whether to redirect when the user got unauthenticated on any API request.
+     * @default false
+     */
+    redirectIfUnauthenticated: boolean;
     /**
      * Laravel Sanctum endpoints to be used by the client.
      */

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -124,7 +124,7 @@ export interface SanctumModuleOptions {
      */
     userStateKey: string;
     /**
-     * Determine whether to redirect when the user is authenticated when on login attempt.
+     * Determine whether to redirect the user if it is already authenticated on a login attempt.
      * @default false
      */
     redirectIfAuthenticated: boolean;


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #116 by providing a new configuration property that enables an automatic client redirection after getting 401 status code from the API.

**Additional context**

To prevent an infinite loop I enable redirects only for CSR mode since SSR will always end up with the user re-initialization.
By default, to keep backward compatibility, `redirectIfUnauthenticated` is false. Also, user identity now will be reset not only on plugin initialization but whenever API returns 401 as well.

Updated configuration docs - [Configuration](https://manchenkoff.gitbook.io/nuxt-auth-sanctum/usage/configuration#available-options)
Updated error handling docs - [Error handling](https://manchenkoff.gitbook.io/nuxt-auth-sanctum/usage/error-handling)

**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
-   [x] Documentation is updated
