### PR TITLE
fix: update to latest `@nuxt/module-builder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@nuxt/devtools": "latest",
     "@nuxt/eslint-config": "^0.3.13",
-    "@nuxt/module-builder": "^0.7.0",
+    "@nuxt/module-builder": "^0.8.3",
     "@nuxt/schema": "^3.9.0",
     "@nuxt/test-utils": "^3.9.0",
     "@types/node": "^20.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,9 +1657,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/module-builder@npm:^0.7.0":
-  version: 0.7.1
-  resolution: "@nuxt/module-builder@npm:0.7.1"
+"@nuxt/module-builder@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@nuxt/module-builder@npm:0.8.3"
   dependencies:
     citty: "npm:^0.1.6"
     consola: "npm:^3.2.3"
@@ -1667,17 +1667,16 @@ __metadata:
     magic-regexp: "npm:^0.8.0"
     mlly: "npm:^1.7.1"
     pathe: "npm:^1.1.2"
-    pkg-types: "npm:^1.1.1"
-    tsconfck: "npm:^3.1.0"
+    pkg-types: "npm:^1.1.3"
+    tsconfck: "npm:^3.1.1"
     unbuild: "npm:^2.0.0"
-    untyped: "npm:^1.4.2"
   peerDependencies:
-    "@nuxt/kit": ^3.12.1
+    "@nuxt/kit": ^3.12.4
     nuxi: ^3.12.0
   bin:
     nuxt-build-module: dist/cli.mjs
     nuxt-module-build: dist/cli.mjs
-  checksum: 10/2c6f4d86869ab81b0f7171521287e7a755118b34bbba9b9ab94a03a27b9b4e659d35d5aa8f34a91eff9cbf9c74b4cc1718d4b4cb651623628ba9852fdbeb5be3
+  checksum: 10/df7999622cdc8b4d2ee4da511a9ac2ce03719bb5d44e36b9ab79e42a68a41a6a5fb89eb2d30c96c74eb665be64591d47fc389a3d806a1570bf491ceeab647c25
   languageName: node
   linkType: hard
 
@@ -7432,7 +7431,7 @@ __metadata:
     "@nuxt/devtools": "npm:latest"
     "@nuxt/eslint-config": "npm:^0.3.13"
     "@nuxt/kit": "npm:^3.9.0"
-    "@nuxt/module-builder": "npm:^0.7.0"
+    "@nuxt/module-builder": "npm:^0.8.3"
     "@nuxt/schema": "npm:^3.9.0"
     "@nuxt/test-utils": "npm:^3.9.0"
     "@types/node": "npm:^20.11.13"
@@ -9554,7 +9553,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.1.0":
+"tsconfck@npm:^3.1.1":
   version: 3.1.1
   resolution: "tsconfck@npm:3.1.1"
   peerDependencies:


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Previous versions of `@nuxt/module-builder` produced incorrect types for files in the `runtime/` directory. Specifically, a `.d.ts` declaration paired with a `.mjs` file. This isn't correct - it should be either `.d.mts`  and `.mjs` or `.d.ts` and `.js`. 

For maximum compatibility, `@nuxt/module-builder` v0.8 switched to `.js` extension for files in `runtime/` directory.

With the latest Nuxt, this is now an error that removes correct plugin injection types.

Related PRs: https://github.com/nuxt/nuxt/pull/28480, https://github.com/nuxt/nuxt/pull/28593
See also https://github.com/nuxt/nuxt/issues/28672.

**Additional context**

Add any other context or screenshots about the feature request here.

**Checklist:**

-   [x] Code style and linters are passing
-   [x] Backwards compatibility is maintained
-   [ ] Documentation is updated
