### PR TITLE
feat: granular control over plugin load order and user request

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export const defaultModuleOptions: ModuleOptions = {
   },
   client: {
     retry: false,
+    initialRequest: true,
   },
   redirect: {
     keepRequestedRoute: false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,4 +31,5 @@ export const defaultModuleOptions: ModuleOptions = {
     allow404WithoutAuth: true,
   },
   logLevel: 3,
+  appendPlugin: false,
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,7 +40,7 @@ export default defineNuxtModule<ModuleOptions>({
       level: sanctumConfig.logLevel,
     })
 
-    addPlugin(resolver.resolve('./runtime/plugin'))
+    addPlugin(resolver.resolve('./runtime/plugin'), { append: sanctumConfig.appendPlugin })
     addImportsDir(resolver.resolve('./runtime/composables'))
 
     if (sanctumConfig.globalMiddleware.enabled) {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,9 +1,10 @@
-import { FetchError } from 'ofetch'
+import { type $Fetch, FetchError } from 'ofetch'
 import { createConsola, type ConsolaInstance } from 'consola'
 import { createHttpClient } from './httpFactory'
 import { useSanctumUser } from './composables/useSanctumUser'
 import { useSanctumConfig } from './composables/useSanctumConfig'
 import { useSanctumAppConfig } from './composables/useSanctumAppConfig'
+import type { ModuleOptions } from './types/options'
 import { defineNuxtPlugin, updateAppConfig, useState } from '#app'
 
 const LOGGER_NAME = 'nuxt-auth-sanctum'
@@ -13,6 +14,41 @@ function createSanctumLogger(logLevel: number) {
   const loggerName = LOGGER_NAME + ':' + envSuffix
 
   return createConsola({ level: logLevel }).withTag(loggerName)
+}
+
+async function setupDefaultTokenStorage(logger: ConsolaInstance) {
+  logger.debug(
+    'Token storage is not defined, switch to default cookie storage',
+  )
+
+  const defaultStorage = await import('./storages/cookieTokenStorage')
+
+  updateAppConfig({
+    sanctum: {
+      tokenStorage: defaultStorage.cookieTokenStorage,
+    },
+  })
+}
+
+async function initialIdentityLoad(client: $Fetch, options: ModuleOptions, logger: ConsolaInstance) {
+  const user = useSanctumUser()
+
+  const identityFetchedOnInit = useState<boolean>(
+    'sanctum.user.loaded',
+    () => false,
+  )
+
+  if (user.value === null && identityFetchedOnInit.value === false) {
+    identityFetchedOnInit.value = true
+
+    try {
+      logger.debug('Fetching user identity on plugin initialization')
+      user.value = await client(options.endpoints.user!)
+    }
+    catch (error) {
+      handleIdentityLoadError(error as Error, logger)
+    }
+  }
 }
 
 function handleIdentityLoadError(error: Error, logger: ConsolaInstance) {
@@ -32,42 +68,16 @@ function handleIdentityLoadError(error: Error, logger: ConsolaInstance) {
 }
 
 export default defineNuxtPlugin(async () => {
-  const user = useSanctumUser()
   const options = useSanctumConfig()
   const appConfig = useSanctumAppConfig()
   const logger = createSanctumLogger(options.logLevel)
   const client = createHttpClient(logger)
 
   if (options.mode === 'token' && !appConfig.tokenStorage) {
-    logger.debug(
-      'Token storage is not defined, switch to default cookie storage',
-    )
-
-    const defaultStorage = await import('./storages/cookieTokenStorage')
-
-    updateAppConfig({
-      sanctum: {
-        tokenStorage: defaultStorage.cookieTokenStorage,
-      },
-    })
+    await setupDefaultTokenStorage(logger)
   }
 
-  const identityFetchedOnInit = useState<boolean>(
-    'sanctum.user.loaded',
-    () => false,
-  )
-
-  if (user.value === null && identityFetchedOnInit.value === false) {
-    identityFetchedOnInit.value = true
-
-    try {
-      logger.debug('Fetching user identity on plugin initialization')
-      user.value = await client(options.endpoints.user!)
-    }
-    catch (error) {
-      handleIdentityLoadError(error as Error, logger)
-    }
-  }
+  await initialIdentityLoad(client, options, logger)
 
   return {
     provide: {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -5,6 +5,7 @@ import { useSanctumUser } from './composables/useSanctumUser'
 import { useSanctumConfig } from './composables/useSanctumConfig'
 import { useSanctumAppConfig } from './composables/useSanctumAppConfig'
 import type { ModuleOptions } from './types/options'
+import { IDENTITY_LOADED_KEY } from './utils/constants'
 import { defineNuxtPlugin, updateAppConfig, useState } from '#app'
 
 const LOGGER_NAME = 'nuxt-auth-sanctum'
@@ -34,7 +35,7 @@ async function initialIdentityLoad(client: $Fetch, options: ModuleOptions, logge
   const user = useSanctumUser()
 
   const identityFetchedOnInit = useState<boolean>(
-    'sanctum.user.loaded',
+    IDENTITY_LOADED_KEY,
     () => false,
   )
 
@@ -77,7 +78,9 @@ export default defineNuxtPlugin(async () => {
     await setupDefaultTokenStorage(logger)
   }
 
-  await initialIdentityLoad(client, options, logger)
+  if (options.client.initialRequest) {
+    await initialIdentityLoad(client, options, logger)
+  }
 
   return {
     provide: {

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -170,4 +170,11 @@ export interface ModuleOptions {
    * @default 3
    */
   logLevel: number
+  /**
+   * Determines whether to append the plugin to the Nuxt application.
+   * Be default, Nuxt prepends the plugin to load it before the application modules.
+   * @default false
+   * @see https://nuxt.com/docs/api/kit/plugins#options
+   */
+  appendPlugin: boolean
 }

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -49,6 +49,11 @@ export interface ClientOptions {
    * @default false
    */
   retry: number | boolean
+  /**
+   * Determines whether to request the user identity on plugin initialization.
+   * @default true
+   */
+  initialRequest: boolean
 }
 
 /**

--- a/src/runtime/utils/constants.ts
+++ b/src/runtime/utils/constants.ts
@@ -1,0 +1,1 @@
+export const IDENTITY_LOADED_KEY = 'sanctum.user.loaded'


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #162 by adding the following features:
- Use the `sanctum.appendPlugin` config key to enable the `append` operation instead of the default `prepend` for the plugin.
- Disable initial user request by changing `sanctum.client.initialRequest` to `false`. A separate method now is exposed in `useSanctumAuth` composable - `init`, which will be executed only once regardless of the selected SSR/CSR environment.

**Additional context**

Since the plugin's `dependsOn` cannot be configured externally (due to module initialization scope), module options cannot be used either.

Now when we need to ensure that the sanctum client makes the initial user request only after some other plugins are loaded (e.g. i18n), we should define a custom local plugin with `dependsOn: ['i18n', 'nuxt-auth-sanctum']` and call `init` method there manually, for instance:

```typescript
// my-custom-auth.ts
export default defineNuxtPlugin({
  name: 'custom-auth',
  dependsOn: ['i18n', 'nuxt-auth-sanctum'],
  async setup() {
    const { init } = useSanctumAuth()
    await init()
  }
})
```