### PR TITLE
fix: keep same session on SSR requests

### DIFF
--- a/src/runtime/interceptors/cookie/request.ts
+++ b/src/runtime/interceptors/cookie/request.ts
@@ -13,6 +13,7 @@ type Headers = HeadersInit | undefined
 
 const SECURE_METHODS = new Set(['post', 'delete', 'put', 'patch'])
 const COOKIE_OPTIONS: { readonly: true } = { readonly: true }
+const CLIENT_HEADERS = ['cookie', 'user-agent']
 
 /**
  * Pass all cookies, headers and referrer from the client to the API
@@ -24,14 +25,14 @@ function buildServerHeaders(
   headers: Headers,
   config: ModuleOptions,
 ): HeadersInit {
-  const clientCookies = useRequestHeaders(['cookie'])
+  const clientHeaders = useRequestHeaders(CLIENT_HEADERS)
   const origin = config.origin ?? useRequestURL().origin
 
   return {
     ...headers,
     Referer: origin,
     Origin: origin,
-    ...(clientCookies.cookie && clientCookies),
+    ...clientHeaders,
   }
 }
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Potentially closes #163 by using the `User-Agent` header from the client request to prevent session regeneration during the hashing process.
