### PR TITLE
fix: use nuxt app context for default token storage

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -28,5 +28,5 @@ export default defineNuxtConfig({
     },
   },
 
-  compatibilityDate: '2024-08-30',
+  compatibilityDate: '2024-09-28',
 })

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -9,7 +9,7 @@ import handleRequestHeaders from './interceptors/common/request'
 import handleRequestTokenHeader from './interceptors/token/request'
 import type { SanctumAppConfig, SanctumInterceptor } from './types/config'
 import type { ModuleOptions } from './types/options'
-import { navigateTo, useNuxtApp } from '#app'
+import { navigateTo, type NuxtApp } from '#app'
 
 function configureClientInterceptors(
   requestInterceptors: SanctumInterceptor[],
@@ -46,11 +46,10 @@ function determineCredentialsMode() {
   return 'include'
 }
 
-export function createHttpClient(logger: ConsolaInstance): $Fetch {
+export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): $Fetch {
   const options = useSanctumConfig()
   const user = useSanctumUser()
   const appConfig = useSanctumAppConfig()
-  const nuxtApp = useNuxtApp()
 
   const requestInterceptors: SanctumInterceptor[] = [handleRequestHeaders]
   const responseInterceptors: SanctumInterceptor[] = []


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

This PR closes #176 by using the Nuxt instance context while setting default token storage in SSR mode.
