### PR TITLE
fix: prevent concurrent update of request headers

### DIFF
--- a/src/runtime/interceptors/common/request.ts
+++ b/src/runtime/interceptors/common/request.ts
@@ -15,11 +15,10 @@ export default async function handleRequestHeaders(
 ): Promise<void> {
   const method = ctx.options.method?.toLowerCase() ?? 'get'
 
-  if (!ctx.options.headers) {
-    ctx.options.headers = {}
-  }
-
-  Object.assign(ctx.options.headers!, { Accept: 'application/json' })
+  ctx.options.headers = Object.assign(
+    ctx.options.headers || {},
+    { Accept: 'application/json' },
+  )
 
   // https://laravel.com/docs/10.x/routing#form-method-spoofing
   if (method === 'put' && ctx.options.body instanceof FormData) {

--- a/src/runtime/interceptors/token/request.ts
+++ b/src/runtime/interceptors/token/request.ts
@@ -23,7 +23,10 @@ export default async function handleRequestTokenHeader(
     return
   }
 
-  Object.assign(ctx.options.headers!, { Authorization: `Bearer ${token}` })
+  ctx.options.headers = Object.assign(
+    ctx.options.headers || {},
+    { Authorization: `Bearer ${token}` },
+  )
 
   logger.debug(
     '[handleRequestTokenHeader] headers modified',


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Should resolve #188 by overwriting the headers instead of setting new values on top of it.
