### PR TITLE
fix: use normalized ofetch headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "changelogen": "^0.5.5",
     "eslint": "^9.9.1",
     "nuxt": "^3.13.2",
+    "ofetch": "^1.4.0",
     "typescript": "^5.5.4",
     "vitest": "^2.0.5",
     "vue-tsc": "^2.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       nuxt:
         specifier: ^3.13.2
         version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@22.7.4)(eslint@9.11.1(jiti@1.21.6))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.22.2)(terser@5.33.0)(typescript@5.5.4)(vite@5.4.7(@types/node@22.7.4)(terser@5.33.0))(vue-tsc@2.1.6(typescript@5.5.4))
+      ofetch:
+        specifier: ^1.4.0
+        version: 1.4.0
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -3001,8 +3004,8 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  ofetch@1.3.4:
-    resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
+  ofetch@1.4.0:
+    resolution: {integrity: sha512-MuHgsEhU6zGeX+EMh+8mSMrYTnsqJQQrpM00Q6QHMKNqQ0bKy0B43tk8tL1wg+CnsSTy1kg4Ir2T5Ig6rD+dfQ==}
 
   ohash@1.1.4:
     resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
@@ -5049,7 +5052,7 @@ snapshots:
       jiti: 1.21.6
       mri: 1.2.0
       nanoid: 5.0.7
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       package-manager-detector: 0.2.0
       parse-git-config: 3.0.0
       pathe: 1.1.2
@@ -5077,7 +5080,7 @@ snapshots:
       magic-string: 0.30.11
       nitropack: 2.9.7(magicast@0.3.5)
       node-fetch-native: 1.6.4
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       pathe: 1.1.2
       perfect-debounce: 1.0.0
       radix3: 1.1.2
@@ -5989,7 +5992,7 @@ snapshots:
       convert-gitmoji: 0.1.5
       mri: 1.2.0
       node-fetch-native: 1.6.4
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       open: 10.1.0
       pathe: 1.1.2
       pkg-types: 1.2.0
@@ -7348,7 +7351,7 @@ snapshots:
       mlly: 1.7.1
       mri: 1.2.0
       node-fetch-native: 1.6.4
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       ohash: 1.1.4
       openapi-typescript: 6.7.6
       pathe: 1.1.2
@@ -7484,7 +7487,7 @@ snapshots:
       nitropack: 2.9.7(magicast@0.3.5)
       nuxi: 3.13.2
       nypm: 0.3.11
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       ohash: 1.1.4
       pathe: 1.1.2
       perfect-debounce: 1.0.0
@@ -7568,7 +7571,7 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  ofetch@1.3.4:
+  ofetch@1.4.0:
     dependencies:
       destr: 2.0.3
       node-fetch-native: 1.6.4
@@ -8494,7 +8497,7 @@ snapshots:
       lru-cache: 10.4.3
       mri: 1.2.0
       node-fetch-native: 1.6.4
-      ofetch: 1.3.4
+      ofetch: 1.4.0
       ufo: 1.5.4
     optionalDependencies:
       ioredis: 5.4.1

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -81,7 +81,7 @@ export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): $Fe
 
       logger.trace(
         `Request headers for "${context.request.toString()}"`,
-        context.options.headers,
+        Object.fromEntries(context.options.headers.entries()),
       )
     },
 
@@ -94,7 +94,7 @@ export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): $Fe
 
       logger.trace(
         `Response headers for "${context.request.toString()}"`,
-        context.response?.headers,
+        context.response ? Object.fromEntries(context.response.headers.entries()) : {},
       )
     },
 

--- a/src/runtime/interceptors/common/request.ts
+++ b/src/runtime/interceptors/common/request.ts
@@ -1,5 +1,6 @@
 import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
+import { appendRequestHeaders } from '../../utils/headers'
 import type { NuxtApp } from '#app'
 
 /**
@@ -16,10 +17,7 @@ export default async function handleRequestHeaders(
   const method = ctx.options.method?.toLowerCase() ?? 'get'
   const headersToAdd = { Accept: 'application/json' }
 
-  ctx.options.headers = Object.assign(
-    ctx.options.headers || {},
-    headersToAdd,
-  )
+  ctx.options.headers = appendRequestHeaders(ctx.options.headers, headersToAdd)
 
   // https://laravel.com/docs/10.x/routing#form-method-spoofing
   if (method === 'put' && ctx.options.body instanceof FormData) {

--- a/src/runtime/interceptors/cookie/request.ts
+++ b/src/runtime/interceptors/cookie/request.ts
@@ -2,6 +2,7 @@ import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { useSanctumConfig } from '../../composables/useSanctumConfig'
 import type { ModuleOptions } from '../../types/options'
+import { appendRequestHeaders } from '../../utils/headers'
 import { type NuxtApp, useCookie, useRequestHeaders, useRequestURL } from '#app'
 
 const SECURE_METHODS = new Set(['post', 'delete', 'put', 'patch'])
@@ -15,10 +16,10 @@ const COOKIE_OPTIONS: { readonly: true } = { readonly: true }
  * @returns Headers collection to pass to the API
  */
 function useServerHeaders(
-  headers: HeadersInit | undefined,
+  headers: Headers,
   config: ModuleOptions,
   logger: ConsolaInstance,
-): HeadersInit {
+): Headers {
   const clientHeaders = useRequestHeaders(['cookie', 'user-agent'])
   const origin = config.origin ?? useRequestURL().origin
 
@@ -34,7 +35,7 @@ function useServerHeaders(
     Object.keys(headersToAdd),
   )
 
-  return Object.assign(headers || {}, headersToAdd)
+  return appendRequestHeaders(headers, headersToAdd)
 }
 
 /**
@@ -67,10 +68,10 @@ async function initCsrfCookie(
  * @returns Headers collection to pass to the API
  */
 async function useCsrfHeader(
-  headers: HeadersInit | undefined,
+  headers: Headers,
   config: ModuleOptions,
   logger: ConsolaInstance,
-): Promise<HeadersInit> {
+): Promise<Headers> {
   if (config.csrf.cookie === undefined) {
     throw new Error('`sanctum.csrf.cookie` is not defined')
   }
@@ -88,14 +89,14 @@ async function useCsrfHeader(
 
   if (!csrfToken.value) {
     logger.warn(`${config.csrf.cookie} cookie is missing, unable to set ${config.csrf.header} header`)
-    return headers || {}
+    return headers
   }
 
   const headersToAdd = { [config.csrf.header]: csrfToken.value }
 
   logger.debug(`[request] added csrf token header`, Object.keys(headersToAdd))
 
-  return Object.assign(headers || {}, headersToAdd)
+  return appendRequestHeaders(headers, headersToAdd)
 }
 
 /**

--- a/src/runtime/interceptors/token/request.ts
+++ b/src/runtime/interceptors/token/request.ts
@@ -1,6 +1,7 @@
 import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { useSanctumAppConfig } from '../../composables/useSanctumAppConfig'
+import { appendRequestHeaders } from '../../utils/headers'
 import type { NuxtApp } from '#app'
 
 /**
@@ -34,5 +35,5 @@ export default async function handleRequestTokenHeader(
     Object.keys(headersToAdd),
   )
 
-  ctx.options.headers = Object.assign(ctx.options.headers || {}, headersToAdd)
+  ctx.options.headers = appendRequestHeaders(ctx.options.headers, headersToAdd)
 }

--- a/src/runtime/utils/headers.ts
+++ b/src/runtime/utils/headers.ts
@@ -1,0 +1,7 @@
+export function appendRequestHeaders(headers: Headers, append: Record<string, string>): Headers {
+  for (const [key, value] of Object.entries(append)) {
+    headers.set(key, value)
+  }
+
+  return headers
+}


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

After `ofetch 1.4.0` release that includes https://github.com/unjs/ofetch/pull/436, `nuxt-auth-sanctum` interceptors stopped working properly due to the usage of `HeadersInit` instead of `Headers` type.

This PR introduces a new helper that appends new headers to the existing `Header` collection. Should fix issues in #188 and #191.
