### PR TITLE
feat: add option to prepend the global middleware

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
     globalMiddleware: {
       allow404WithoutAuth: true,
       enabled: false,
+      prepend: false,
     },
   },
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export const defaultModuleOptions: ModuleOptions = {
   },
   globalMiddleware: {
     enabled: false,
+    prepend: false,
     allow404WithoutAuth: true,
   },
   logLevel: 3,

--- a/src/module.ts
+++ b/src/module.ts
@@ -48,6 +48,8 @@ export default defineNuxtModule<ModuleOptions>({
         name: 'sanctum:auth:global',
         path: resolver.resolve('./runtime/middleware/sanctum.global'),
         global: true,
+      }, {
+        prepend: sanctumConfig.globalMiddleware.prepend,
       })
 
       logger.info('Sanctum module initialized with global middleware')

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -101,6 +101,11 @@ export interface GlobalMiddlewareOptions {
    */
   enabled: boolean
   /**
+   * Determines whether the global middleware is prepended.
+   * @default false
+   */
+  prepend: boolean
+  /**
    * Determines whether to allow 404 pages without authentication.
    * @default true
    */


### PR DESCRIPTION
Middlewares from modules have lower order from the ones in the middleware folder. This is a problem if we want to run an auth related global middleware.

For example, we want to run `sanctum:auth:global` to check if the user is authenticated before running a global middleware to check if the user has the right permissions.

This adds support for prepending the `sanctum:auth:global` middleware to the list of existing middleware, more info [here](https://nuxt.com/docs/api/kit/pages#addroutemiddleware).

```js
globalMiddleware: {
  // Default value is false
  prepend: true,
},
```