### PR TITLE
fix: use Nuxt `$fetch` type for client

### DIFF
--- a/playground/server/api/test.get.ts
+++ b/playground/server/api/test.get.ts
@@ -1,0 +1,5 @@
+import type { H3Event } from 'h3'
+
+export default defineEventHandler((_event: H3Event) => {
+  return 'Hello, World!'
+})

--- a/src/runtime/composables/useSanctumClient.ts
+++ b/src/runtime/composables/useSanctumClient.ts
@@ -1,7 +1,6 @@
-import type { $Fetch } from 'ofetch'
 import { useNuxtApp } from '#app'
 
-export const useSanctumClient = (): $Fetch => {
+export const useSanctumClient = (): typeof $fetch => {
   const { $sanctumClient } = useNuxtApp()
-  return $sanctumClient as $Fetch
+  return $sanctumClient
 }

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -1,4 +1,4 @@
-import type { $Fetch, FetchContext, FetchOptions } from 'ofetch'
+import type { FetchContext, FetchOptions } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { useSanctumUser } from './composables/useSanctumUser'
 import { useSanctumConfig } from './composables/useSanctumConfig'
@@ -56,7 +56,7 @@ function determineCredentialsMode() {
   return 'include'
 }
 
-export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): $Fetch {
+export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): typeof $fetch {
   const options = useSanctumConfig()
   const user = useSanctumUser()
   const appConfig = useSanctumAppConfig()
@@ -128,5 +128,5 @@ export function createHttpClient(nuxtApp: NuxtApp, logger: ConsolaInstance): $Fe
     },
   }
 
-  return $fetch.create(httpOptions) as $Fetch
+  return $fetch.create(httpOptions) as typeof $fetch
 }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { type $Fetch, FetchError } from 'ofetch'
+import { FetchError } from 'ofetch'
 import { createConsola, type ConsolaInstance } from 'consola'
 import { createHttpClient } from './httpFactory'
 import { useSanctumUser } from './composables/useSanctumUser'
@@ -33,7 +33,7 @@ async function setupDefaultTokenStorage(nuxtApp: NuxtApp, logger: ConsolaInstanc
   })
 }
 
-async function initialIdentityLoad(client: $Fetch, options: ModuleOptions, logger: ConsolaInstance) {
+async function initialIdentityLoad(client: typeof $fetch, options: ModuleOptions, logger: ConsolaInstance) {
   const user = useSanctumUser()
 
   const identityFetchedOnInit = useState<boolean>(


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

There is an issue where server routes aren't being type-hinted by the packages client as it's using the type of `$Fetch` from `ofetch` which doesn't seem to be enriched with Nuxt server routes type hinting features.

Before

```ts
const client = useSanctumClient()
client('') // No suggestion made
```

After

```ts
const client = useSanctumClient()
client('') // -> /api/test
```

This PR ensures that the client is typed just like Nuxt `$fetch` helper.