### PR TITLE
fix: deduplicate `set-cookie` headers on SSR response

### DIFF
--- a/src/runtime/interceptors/cookie/response.ts
+++ b/src/runtime/interceptors/cookie/response.ts
@@ -1,7 +1,10 @@
-import { appendResponseHeader, splitCookiesString } from 'h3'
+import type { OutgoingHttpHeaders } from 'node:http'
+import { getResponseHeaders, type H3Event, setResponseHeaders, splitCookiesString, type TypedHeaders } from 'h3'
 import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { navigateTo, useRequestEvent, type NuxtApp } from '#app'
+
+const ServerCookieName = 'set-cookie'
 
 /**
  * Append server response headers to the client response
@@ -15,28 +18,87 @@ function appendServerResponseHeaders(
   logger: ConsolaInstance,
 ): void {
   const event = useRequestEvent(app)
-  const serverCookieName = 'set-cookie'
-  const cookieHeader = ctx.response!.headers.get(serverCookieName)
 
-  if (cookieHeader === null || event === undefined) {
-    logger.debug(`[response] no cookies to pass to the client [${ctx.request}]`)
+  if (event === undefined) {
+    logger.debug(`[response] no event to pass cookies to the client [${ctx.request}]`)
     return
   }
 
-  const cookies = splitCookiesString(cookieHeader)
-  const cookieNameList = []
+  const eventHeaders = getResponseHeaders(event)
 
-  for (const cookie of cookies) {
-    appendResponseHeader(event, serverCookieName, cookie)
+  const cookiesFromEvent = extractCookiesFromEventHeaders(eventHeaders)
+  const cookiesFromResponse = extractCookiesFromResponse(ctx, logger)
 
-    const cookieName = cookie.split('=')[0]
-    cookieNameList.push(cookieName)
-  }
+  const cookiesMap = createCookiesMap(cookiesFromEvent, cookiesFromResponse)
+
+  writeCookiesToEventResponse(event, eventHeaders, cookiesMap)
 
   logger.debug(
     `[response] pass cookies from server to client response`,
-    cookieNameList,
+    Array.from(cookiesMap.keys()),
   )
+}
+
+/**
+ * Extract cookies from the current H3 event headers
+ * @param headers HTTP headers collection
+ */
+function extractCookiesFromEventHeaders(headers: OutgoingHttpHeaders): string[] {
+  const cookieHeader = headers[ServerCookieName] ?? []
+
+  if (Array.isArray(cookieHeader)) {
+    return cookieHeader
+  }
+
+  return [cookieHeader]
+}
+
+/**
+ * Extract cookies from the remote API response headers
+ * @param ctx Remote API fetch context
+ * @param logger Module logger instance
+ */
+function extractCookiesFromResponse(ctx: FetchContext, logger: ConsolaInstance): string[] {
+  const cookieHeader = ctx.response!.headers.get(ServerCookieName)
+
+  if (cookieHeader === null) {
+    logger.debug(`[response] no cookies to pass to the client [${ctx.request}]`)
+    return []
+  }
+
+  return splitCookiesString(cookieHeader)
+}
+
+/**
+ * Create a map of cookies to deduplicate them
+ * @param cookieCollections Arrays of cookies to merge
+ */
+function createCookiesMap(...cookieCollections: string[][]) {
+  const cookiesMap = new Map<string, string>()
+
+  for (const cookies of cookieCollections) {
+    for (const cookie of cookies) {
+      const cookieName = cookie.split('=')[0]
+      cookiesMap.set(cookieName, cookie)
+    }
+  }
+
+  return cookiesMap
+}
+
+/**
+ * Write cookies to the event response headers, keeping the original headers
+ * @param event H3 event instance
+ * @param headers HTTP headers collection
+ * @param cookiesMap Cookies map
+ */
+function writeCookiesToEventResponse(event: H3Event, headers: OutgoingHttpHeaders, cookiesMap: Map<string, string>) {
+  const mergedHeaders = {
+    ...headers,
+    [ServerCookieName]: Array.from(cookiesMap.values()),
+  } as TypedHeaders
+
+  setResponseHeaders(event, mergedHeaders)
 }
 
 /**

--- a/src/runtime/interceptors/cookie/response.ts
+++ b/src/runtime/interceptors/cookie/response.ts
@@ -79,6 +79,11 @@ function createCookiesMap(...cookieCollections: string[][]) {
   for (const cookies of cookieCollections) {
     for (const cookie of cookies) {
       const cookieName = cookie.split('=')[0]
+
+      if (cookieName === undefined) {
+        continue
+      }
+
       cookiesMap.set(cookieName, cookie)
     }
   }


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #298 by deduplicating `set-cookie` headers in the response of Nuxt SSR (H3) when multiple requests are made against Laravel API. All other headers are preserved and should not be omitted.
