### PR TITLE
feat: added new composables to make requests

### DIFF
--- a/src/runtime/composables/useLazySanctumFetch.ts
+++ b/src/runtime/composables/useLazySanctumFetch.ts
@@ -1,0 +1,14 @@
+import type { UseFetchOptions } from 'nuxt/app'
+import { useLazyFetch, useSanctumClient } from '#imports'
+
+export function useLazySanctumFetch<T>(
+  url: string | (() => string),
+  options?: UseFetchOptions<T>,
+) {
+  const client = useSanctumClient()
+
+  return useLazyFetch(url, {
+    ...options,
+    $fetch: client as typeof $fetch,
+  })
+}

--- a/src/runtime/composables/useSanctumFetch.ts
+++ b/src/runtime/composables/useSanctumFetch.ts
@@ -1,0 +1,14 @@
+import type { UseFetchOptions } from 'nuxt/app'
+import { useFetch, useSanctumClient } from '#imports'
+
+export function useSanctumFetch<T>(
+  url: string | (() => string),
+  options?: UseFetchOptions<T>,
+) {
+  const client = useSanctumClient()
+
+  return useFetch(url, {
+    ...options,
+    $fetch: client as typeof $fetch,
+  })
+}


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #305 by adding two new composables:
- `useSanctumFetch`
- `useLazySanctumFetch`

These composables provide the same functionality as `useFetch`/`useLazyFetch` but with preconfigured `sanctum` client to take care of CSRF, cookies, etc.
