### PR TITLE
fix: migrated from useFetch to useAsyncData

### DIFF
--- a/src/runtime/composables/useLazySanctumFetch.ts
+++ b/src/runtime/composables/useLazySanctumFetch.ts
@@ -1,18 +1,12 @@
-import type { UseFetchOptions } from 'nuxt/app'
-import type { FetchError } from 'ofetch'
-import { useLazyFetch, useSanctumClient } from '#imports'
-import type { KeysOf, PickFrom, AsyncData } from '#app/composables/asyncData'
-
-type LazyFetchResponse<T> = AsyncData<PickFrom<T, KeysOf<T>> | null, FetchError | null | undefined>
+import type { FetchOptions } from 'ofetch'
+import { useLazyAsyncData, useSanctumClient } from '#imports'
+import type { AsyncData, KeysOf, PickFrom } from '#app/composables/asyncData'
 
 export function useLazySanctumFetch<T>(
-  url: string | (() => string),
-  options?: UseFetchOptions<T>,
-): LazyFetchResponse<T> {
+  url: string,
+  options?: FetchOptions,
+): AsyncData<PickFrom<T, KeysOf<T>> | null | undefined, Error | null | undefined> {
   const client = useSanctumClient()
 
-  return useLazyFetch(url, {
-    ...options,
-    $fetch: client as typeof $fetch,
-  }) as LazyFetchResponse<T>
+  return useLazyAsyncData<T>(() => client<T>(url, options as FetchOptions<'json'>))
 }

--- a/src/runtime/composables/useSanctumFetch.ts
+++ b/src/runtime/composables/useSanctumFetch.ts
@@ -1,18 +1,12 @@
-import type { UseFetchOptions } from 'nuxt/app'
-import type { FetchError } from 'ofetch'
-import { useFetch, useSanctumClient } from '#imports'
+import type { FetchOptions } from 'ofetch'
+import { useAsyncData, useSanctumClient } from '#imports'
 import type { AsyncData, KeysOf, PickFrom } from '#app/composables/asyncData'
 
-type FetchResponse<T> = AsyncData<PickFrom<T, KeysOf<T>> | null, FetchError | null | undefined>
-
 export function useSanctumFetch<T>(
-  url: string | (() => string),
-  options?: UseFetchOptions<T>,
-): FetchResponse<T> {
+  url: string,
+  options?: FetchOptions,
+): AsyncData<PickFrom<T, KeysOf<T>> | null | undefined, Error | null | undefined> {
   const client = useSanctumClient()
 
-  return useFetch(url, {
-    ...options,
-    $fetch: client as typeof $fetch,
-  }) as FetchResponse<T>
+  return useAsyncData<T>(() => client<T>(url, options as FetchOptions<'json'>))
 }


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Fixes #308 by using `useAsyncData` instead of `useFetch` with custom client. The main reason is the different visibility of `useFetch` within Nuxt global namespace / module / layers. Thus, this composable is recommended only at the application level.
