### PR TITLE
324-feature-hooks-identity-fetch-init-event

### DIFF
--- a/playground/app/plugins/sanctum.hooks.ts
+++ b/playground/app/plugins/sanctum.hooks.ts
@@ -6,4 +6,12 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('sanctum:redirect', (url) => {
     console.log('Sanctum redirect hook triggered', url)
   })
+
+  nuxtApp.hook('sanctum:init', () => {
+    console.log('Sanctum init hook triggered')
+  })
+
+  nuxtApp.hook('sanctum:refresh', () => {
+    console.log('Sanctum refresh hook triggered')
+  })
 })

--- a/src/runtime/composables/useSanctumAuth.ts
+++ b/src/runtime/composables/useSanctumAuth.ts
@@ -52,7 +52,9 @@ export const useSanctumAuth = <T>(): SanctumAuth<T> => {
     }
 
     isIdentityLoaded.value = true
+
     await refreshIdentity()
+    await nuxtApp.callHook('sanctum:init')
   }
 
   /**
@@ -60,6 +62,7 @@ export const useSanctumAuth = <T>(): SanctumAuth<T> => {
    */
   async function refreshIdentity() {
     user.value = await client<T>(options.endpoints.user!)
+    await nuxtApp.callHook('sanctum:refresh')
   }
 
   /**

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -33,7 +33,7 @@ async function setupDefaultTokenStorage(nuxtApp: NuxtApp, logger: ConsolaInstanc
   })
 }
 
-async function initialIdentityLoad(client: $Fetch, options: ModuleOptions, logger: ConsolaInstance) {
+async function initialIdentityLoad(nuxtApp: NuxtApp, client: $Fetch, options: ModuleOptions, logger: ConsolaInstance) {
   const user = useSanctumUser()
 
   const identityFetchedOnInit = useState<boolean>(
@@ -52,6 +52,7 @@ async function initialIdentityLoad(client: $Fetch, options: ModuleOptions, logge
 
     try {
       user.value = await client(options.endpoints.user)
+      await nuxtApp.callHook('sanctum:init')
     }
     catch (error) {
       handleIdentityLoadError(error as Error, logger)
@@ -89,7 +90,7 @@ export default defineNuxtPlugin({
     }
 
     if (options.client.initialRequest) {
-      await initialIdentityLoad(client, options, logger)
+      await initialIdentityLoad(nuxtApp, client, options, logger)
     }
 
     return {

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -182,7 +182,7 @@ export interface ModuleOptions {
   logLevel: number
   /**
    * Determines whether to append the plugin to the Nuxt application.
-   * Be default, Nuxt prepends the plugin to load it before the application modules.
+   * By default, Nuxt prepends the plugin to load it before the application modules.
    * @default false
    * @see https://nuxt.com/docs/api/kit/plugins#options
    */

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -48,6 +48,14 @@ declare module '#app' {
      * Triggers when user has been redirected.
      */
     'sanctum:redirect': (path: string) => HookResult
+    /**
+     * Triggers when an initial user identity request has been made.
+     */
+    'sanctum:init': () => HookResult
+    /**
+     * Triggers when user identity has been refreshed.
+     */
+    'sanctum:refresh': () => HookResult
   }
 }
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #324 by introducing new hooks to notify client code about fetching user identity:
- `sanctum:init`
- `sanctum:refresh`
