### PR TITLE
feat(fetch)!: support AsyncDataOptions in sanctum fetch composables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,33 @@ pnpm test
 pnpm test:watch
 ```
 
+# Testing package locally
+
+If you want to test the package before publishing it to `npm`, 
+you can create an archive and install it as a dependency in your project.
+
+To do this, run the following command:
+
+```bash
+pnpm rc
+```
+
+This will create a `.tgz` file in the `dist` directory. You can then reference it in your project:
+
+```json
+{
+  "devDependencies": {
+    "nuxt-auth-sanctum": "file:/dist/nuxt-auth-sanctum-0.0.0.tgz"
+  }
+}
+```
+
+Then you can install the package by running:
+
+```bash
+pnpm install
+```
+
 # Code Style and Standards
 
 This project uses ESLint to enforce code style and standards. Please make sure to run the following commands before creating a pull request:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "prepack": "nuxt-module-build build",
+    "rc": "pnpm pack --pack-destination dist",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",

--- a/src/runtime/utils/fetch.ts
+++ b/src/runtime/utils/fetch.ts
@@ -1,0 +1,22 @@
+import type { FetchOptions } from 'ofetch'
+
+export function assembleFetchRequestKey(
+  url: string,
+  lazy: boolean,
+  options?: FetchOptions,
+): string {
+  const operation = lazy ? 'lazy-fetch' : 'fetch'
+
+  const parts = [
+    'sanctum',
+    operation,
+    url,
+    options?.method ?? 'get',
+    JSON.stringify({
+      query: options?.query ?? {},
+      body: options?.body ?? {},
+    }),
+  ]
+
+  return parts.join(':')
+}


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #330 by introducing a new optional argument for `useSanctumFetch` and `useLazySanctumFetch` composables. Now we can pass options for `useAsyncData` used underneath and also keep the ability to pass `FetchOptions` for the client used inside of `useAsyncData` call handler.
