### PR TITLE
fix(init): use raw fetch to handle errors on identity init

### DIFF
--- a/src/runtime/interceptors/common/response.ts
+++ b/src/runtime/interceptors/common/response.ts
@@ -15,7 +15,7 @@ const validateCookieHeader: HeaderValidator = (
   }
 
   if (!headers.has('set-cookie')) {
-    logger.warn('[response] `set-cookie` header is missing')
+    logger.warn('[response] `set-cookie` header is missing, CSRF token will not be set')
   }
 }
 
@@ -27,7 +27,7 @@ const validateContentTypeHeader: HeaderValidator = (
   const contentType = headers.get('content-type')
 
   if (!contentType || !contentType.includes('application/json')) {
-    logger.warn('[response] `content-type` header is missing or invalid')
+    logger.warn(`[response] 'content-type' header is missing or invalid (expected: application/json, got: ${contentType})`)
   }
 }
 
@@ -43,7 +43,7 @@ const validateCredentialsHeader: HeaderValidator = (
   const allowCredentials = headers.get('access-control-allow-credentials')
 
   if (!allowCredentials || allowCredentials !== 'true') {
-    logger.warn('[response] `access-control-allow-credentials` header is missing or invalid')
+    logger.warn(`[response] 'access-control-allow-credentials' header is missing or invalid (expected: true, got: ${allowCredentials})`)
   }
 }
 
@@ -56,7 +56,7 @@ const validateOriginHeader: HeaderValidator = (
   const currentOrigin = config?.origin ?? useRequestURL().origin
 
   if (!allowOrigin || !allowOrigin.includes(currentOrigin)) {
-    logger.warn('[response] `access-control-allow-origin` header is missing or invalid')
+    logger.warn(`[response] 'access-control-allow-origin' header is missing or invalid (expected: ${currentOrigin}, got: ${allowOrigin})`)
   }
 }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -5,6 +5,7 @@ import { setup, $fetch } from '@nuxt/test-utils'
 describe('ssr', async () => {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
+    port: 51000,
   })
 
   it('renders the index page', async () => {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -6,7 +6,11 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       sanctum: {
-        baseUrl: 'http://localhost:80',
+        baseUrl: '/',
+        endpoints: {
+          csrf: '/api/csrf',
+          user: '/api/user',
+        },
       },
     },
   },

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -1,5 +1,11 @@
 {
-    "private": true,
-    "name": "basic",
-    "type": "module"
+  "private": true,
+  "name": "basic",
+  "type": "module",
+  "scripts": {
+    "build": "nuxi build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  }
 }

--- a/test/fixtures/basic/server/api/csrf.ts
+++ b/test/fixtures/basic/server/api/csrf.ts
@@ -1,0 +1,13 @@
+import { getRequestURL, type H3Event, appendResponseHeaders, defineEventHandler } from 'h3'
+
+export default defineEventHandler((event: H3Event) => {
+  const { protocol } = getRequestURL(event)
+
+  appendResponseHeaders(event, {
+    'Access-Control-Allow-Credentials': true,
+    'Access-Control-Allow-Origin': `${protocol}//127.0.0.1:51000`,
+    'set-cookie': 'XSRF-TOKEN=csrf-cookie; path=/; secure; samesite=lax; httponly',
+  })
+
+  return {}
+})

--- a/test/fixtures/basic/server/api/user.ts
+++ b/test/fixtures/basic/server/api/user.ts
@@ -1,0 +1,16 @@
+import { getRequestURL, type H3Event, appendResponseHeaders, defineEventHandler } from 'h3'
+
+export default defineEventHandler((event: H3Event) => {
+  const { protocol } = getRequestURL(event)
+
+  appendResponseHeaders(event, {
+    'Access-Control-Allow-Credentials': true,
+    'Access-Control-Allow-Origin': `${protocol}//127.0.0.1:51000`,
+    'set-cookie': 'XSRF-TOKEN=csrf-cookie; path=/; secure; samesite=lax; httponly',
+  })
+
+  return {
+    id: 1,
+    name: 'John Doe',
+  }
+})

--- a/test/fixtures/basic/tsconfig.json
+++ b/test/fixtures/basic/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

In some cases, module writes too many logs about logged-out user on plugin initialisation due to incorrect typing of `FetchError`.

This PR fixes that by manually handling `FetchResponse` and 401/419 statuses to hide redundant logs under `debug` level.
