### PR TITLE
feat(client): allow overriding of Accept header per request

### DIFF
--- a/src/runtime/interceptors/common/request.ts
+++ b/src/runtime/interceptors/common/request.ts
@@ -15,18 +15,24 @@ export default async function handleRequestHeaders(
   logger: ConsolaInstance,
 ): Promise<void> {
   const method = ctx.options.method?.toLowerCase() ?? 'get'
-  const headersToAdd = { Accept: 'application/json' }
 
-  ctx.options.headers = appendRequestHeaders(ctx.options.headers, headersToAdd)
+  if (!ctx.options.headers?.has('Accept')) {
+    const headersToAdd = { Accept: 'application/json' }
+
+    ctx.options.headers = appendRequestHeaders(
+      ctx.options.headers,
+      headersToAdd,
+    )
+
+    logger.debug(
+      '[request] added default headers',
+      Object.keys(headersToAdd),
+    )
+  }
 
   // https://laravel.com/docs/10.x/routing#form-method-spoofing
   if (method === 'put' && ctx.options.body instanceof FormData) {
     ctx.options.method = 'POST'
     ctx.options.body.append('_method', 'PUT')
   }
-
-  logger.debug(
-    '[request] added default headers',
-    Object.keys(headersToAdd),
-  )
 }


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Allows users to override `Accept` header value for custom scenarios, when non-JSON response is expected.

For example, when using StreamResponse in Laravel

```php
final class QuoteController extends Controller
{
    public function __invoke(Request $request): JsonResponse|StreamedResponse
    {
        /** @var string $quote */
        $quote = Inspiring::quotes()->random();
        [$text, $author] = explode(' - ', $quote);

        if ($request->header('Accept') === 'text/event-stream') {
            return response()->eventStream(
                function () use ($text, $author) {
                    yield $text;
                }
            );
        }

        $data = [
            'text' => $text,
            'author' => $author,
        ];

        return response()->json($data);
    }
}
```

In this case, in the Nuxt application we can make a request by using `useSanctumClient` like this:

```typescript
const sanctumFetch = useSanctumClient()
const response = await sanctumFetch<ReadableStream, 'stream'>(
    '/api/quote',
    {
        headers: {
            Accept: 'text/event-stream',
        },
        responseType: 'stream',
    },
)

const reader = response.pipeThrough(new TextDecoderStream()).getReader()

while (true) {
    const { value, done } = await reader.read()

    if (done)
        break

    console.log('Received:', value)
}
```
