### PR TITLE
feat: added nuxt server proxy endpoint

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
   },
   compatibilityDate: '2024-09-28',
   sanctum: {
-    baseUrl: 'http://localhost:80',
+    baseUrl: '/api/sanctum',
     mode: 'cookie',
     logLevel: 4,
     redirect: {
@@ -27,6 +27,11 @@ export default defineNuxtConfig({
       allow404WithoutAuth: true,
       enabled: false,
       prepend: false,
+    },
+    serverProxy: {
+      enabled: true,
+      route: '/api/sanctum',
+      baseUrl: 'http://localhost:80',
     },
   },
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,4 +34,9 @@ export const defaultModuleOptions: ModuleOptions = {
   },
   logLevel: 3,
   appendPlugin: false,
+  serverProxy: {
+    enabled: false,
+    route: '/api/sanctum',
+    baseUrl: 'http://localhost:80',
+  },
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,7 @@ import {
   addImportsDir,
   addRouteMiddleware,
   useLogger,
+  addServerHandler,
 } from '@nuxt/kit'
 import { defu } from 'defu'
 import { defaultModuleOptions } from './config'
@@ -65,6 +66,15 @@ export default defineNuxtModule<ModuleOptions>({
       })
 
       logger.info('Sanctum module initialized w/o global middleware')
+    }
+
+    if (sanctumConfig.serverProxy.enabled) {
+      addServerHandler({
+        route: `${sanctumConfig.serverProxy.route}/**`,
+        handler: resolver.resolve('./runtime/server/api/proxy'),
+      })
+
+      logger.info('Sanctum module initialized with server proxy')
     }
 
     registerTypeTemplates(resolver)

--- a/src/runtime/composables/useSanctumAppConfig.ts
+++ b/src/runtime/composables/useSanctumAppConfig.ts
@@ -1,5 +1,5 @@
 import type { SanctumAppConfig } from '../types/config'
-import { useAppConfig } from '#app'
+import { useAppConfig } from '#imports'
 
 export const useSanctumAppConfig = (): SanctumAppConfig => {
   return (useAppConfig().sanctum ?? {}) as SanctumAppConfig

--- a/src/runtime/composables/useSanctumConfig.ts
+++ b/src/runtime/composables/useSanctumConfig.ts
@@ -1,5 +1,5 @@
 import type { ModuleOptions } from '../types/options'
-import { useRuntimeConfig } from '#app'
+import { useRuntimeConfig } from '#imports'
 
 export const useSanctumConfig = (): ModuleOptions => {
   return useRuntimeConfig().public.sanctum as ModuleOptions

--- a/src/runtime/httpFactory.ts
+++ b/src/runtime/httpFactory.ts
@@ -3,6 +3,7 @@ import type { ConsolaInstance } from 'consola'
 import { useSanctumConfig } from './composables/useSanctumConfig'
 import type { SanctumInterceptor } from './types/config'
 import { interceptors } from './interceptors'
+import { determineCredentialsMode } from './utils/credentials'
 import type { SanctumFetch } from './types/fetch'
 import type { NuxtApp } from '#app'
 
@@ -21,20 +22,6 @@ function useClientInterceptors(): [
   ]
 
   return [request, response, responseError]
-}
-
-/**
- * Determines the credentials mode for the fetch request.
- */
-function determineCredentialsMode() {
-  // Fix for Cloudflare workers - https://github.com/cloudflare/workers-sdk/issues/2514
-  const isCredentialsSupported = 'credentials' in Request.prototype
-
-  if (!isCredentialsSupported) {
-    return undefined
-  }
-
-  return 'include'
 }
 
 /**

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,21 +1,13 @@
 import type { $Fetch } from 'ofetch'
-import { createConsola, type ConsolaInstance } from 'consola'
+import type { ConsolaInstance } from 'consola'
 import { createHttpClient } from './httpFactory'
 import { useSanctumUser } from './composables/useSanctumUser'
 import { useSanctumConfig } from './composables/useSanctumConfig'
 import { useSanctumAppConfig } from './composables/useSanctumAppConfig'
 import type { ModuleOptions } from './types/options'
 import { IDENTITY_LOADED_KEY } from './utils/constants'
+import { useSanctumLogger } from './utils/logging'
 import { defineNuxtPlugin, updateAppConfig, useState, type NuxtApp } from '#app'
-
-const LOGGER_NAME = 'nuxt-auth-sanctum'
-
-function createSanctumLogger(logLevel: number) {
-  const envSuffix = import.meta.server ? 'ssr' : 'csr'
-  const loggerName = LOGGER_NAME + ':' + envSuffix
-
-  return createConsola({ level: logLevel }).withTag(loggerName)
-}
 
 async function setupDefaultTokenStorage(nuxtApp: NuxtApp, logger: ConsolaInstance) {
   logger.debug(
@@ -83,7 +75,7 @@ export default defineNuxtPlugin({
     const nuxtApp = _nuxtApp as NuxtApp
     const options = useSanctumConfig()
     const appConfig = useSanctumAppConfig()
-    const logger = createSanctumLogger(options.logLevel)
+    const logger = useSanctumLogger(options.logLevel)
     const client = createHttpClient(nuxtApp, logger)
 
     if (options.mode === 'token' && !appConfig.tokenStorage) {

--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -1,0 +1,51 @@
+import {
+  type H3Event,
+  type EventHandlerRequest,
+  type HTTPMethod,
+  appendResponseHeader,
+} from 'h3'
+import { defineEventHandler, getRequestHeaders, readBody, getQuery, setResponseStatus } from 'h3'
+import { $fetch } from 'ofetch'
+import { useSanctumConfig } from '../../composables/useSanctumConfig'
+import { useSanctumLogger } from '../../utils/logging'
+import { determineCredentialsMode } from '../../utils/credentials'
+
+const METHODS_WITH_BODY: HTTPMethod[] = ['POST', 'PUT', 'PATCH', 'DELETE']
+
+export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
+  const config = useSanctumConfig()
+  const logger = useSanctumLogger(config.logLevel)
+
+  const
+    method = event.method,
+    query = getQuery(event),
+    body = METHODS_WITH_BODY.includes(method) ? await readBody(event) : undefined,
+    headers = getRequestHeaders(event),
+    proxyRoute = event.context.params?._
+
+  const targetUrl = `${config.serverProxy.baseUrl}/${proxyRoute}`
+
+  logger.debug(`[sanctum] proxying request to ${targetUrl}`)
+
+  const response = await $fetch.raw(targetUrl, {
+    method: method,
+    query: query,
+    body: body,
+    credentials: determineCredentialsMode(),
+    headers: {
+      accept: 'application/json',
+      ...headers,
+    } as HeadersInit,
+    ignoreResponseError: true,
+  })
+
+  response.headers.forEach((value, key) => {
+    appendResponseHeader(event, key, value)
+  })
+
+  setResponseStatus(event, response.status)
+
+  logger.debug(`[sanctum] proxying response from ${targetUrl}`)
+
+  return response._data
+})

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -113,6 +113,28 @@ export interface GlobalMiddlewareOptions {
 }
 
 /**
+ * Server API proxy configuration to handle Laravel requests on SSR-side first.
+ */
+export interface ServerProxy {
+  /**
+   * Determines whether the server side proxy is enabled.
+   * @default false
+   */
+  enabled: boolean
+  /**
+   * Nuxt server route to catch all requests. This route will receive any nested path as well,
+   * for instance: `/api/sanctum` will also catch `/api/sanctum/login` and `/api/sanctum/user/info`.
+   * @default '/api/sanctum'
+   */
+  route: string
+  /**
+   * The base URL of the Laravel API.
+   * @default 'http://localhost:80'
+   */
+  baseUrl: string
+}
+
+/**
  * Options to be passed to the plugin.
  */
 export interface ModuleOptions {
@@ -187,4 +209,8 @@ export interface ModuleOptions {
    * @see https://nuxt.com/docs/api/kit/plugins#options
    */
   appendPlugin: boolean
+  /**
+   * Server API proxy configuration to handle Laravel requests on SSR-side first.
+   */
+  serverProxy: ServerProxy
 }

--- a/src/runtime/utils/credentials.ts
+++ b/src/runtime/utils/credentials.ts
@@ -1,0 +1,13 @@
+/**
+ * Determines the credentials mode for the fetch request.
+ */
+export function determineCredentialsMode() {
+  // Fix for Cloudflare workers - https://github.com/cloudflare/workers-sdk/issues/2514
+  const isCredentialsSupported = 'credentials' in Request.prototype
+
+  if (!isCredentialsSupported) {
+    return undefined
+  }
+
+  return 'include'
+}

--- a/src/runtime/utils/logging.ts
+++ b/src/runtime/utils/logging.ts
@@ -1,0 +1,10 @@
+import { type ConsolaInstance, createConsola } from 'consola'
+
+const LOGGER_NAME = 'nuxt-auth-sanctum'
+
+export function useSanctumLogger(logLevel: number): ConsolaInstance {
+  const envSuffix = import.meta.server ? 'ssr' : 'csr'
+  const loggerName = LOGGER_NAME + ':' + envSuffix
+
+  return createConsola({ level: logLevel }).withTag(loggerName)
+}


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention the issues.**

This PR introduces a Nuxt Server API as a proxy to the Laravel API to use a single entry point for all requests while taking care of all the headers and cookies needed to be sent to the target server.

This approach removes the need to set up `routeRules` and can be used without additional code changes on the client side. 

We introduce `serverProxy` config, which defines the catch-all endpoint properties:
- `enabled`: if false, the endpoint won't be used by the app
- `endpoint`: route of Nuxt server endpoint to handle all requests (catch-all)
- `baseUrl`: Laravel API baseUrl to be used for proxying

This implies that the main `baseUrl` used previously with Laravel API URL has to be replaced with `endpoint` from `serverProxy` configuration now.