### PR TITLE
fix: ignore reprocessed response content headers

### DIFF
--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -11,6 +11,7 @@ import { useSanctumLogger } from '../../utils/logging'
 import { determineCredentialsMode } from '../../utils/credentials'
 
 const METHODS_WITH_BODY: HTTPMethod[] = ['POST', 'PUT', 'PATCH', 'DELETE']
+const HEADERS_TO_IGNORE = ['content-length', 'content-encoding', 'transfer-encoding']
 
 export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
   const config = useSanctumConfig()
@@ -40,6 +41,10 @@ export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) =>
   })
 
   response.headers.forEach((value, key) => {
+    if (HEADERS_TO_IGNORE.includes(key.toLowerCase())) {
+      return
+    }
+
     appendResponseHeader(event, key, value)
   })
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Fixes #390 problem related to failing response read due to decompressed body on the server side.
