### PR TITLE
feat: hide serverProxy endpoint from runtime config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -9,12 +9,13 @@ import {
 } from '@nuxt/kit'
 import { defu } from 'defu'
 import { defaultModuleOptions } from './config'
-import type { ModuleOptions } from './runtime/types/options'
+import type { PublicModuleOptions, ModuleOptions } from './runtime/types/options'
 import { registerTypeTemplates } from './templates'
 
 const MODULE_NAME = 'nuxt-auth-sanctum'
 
-export type ModulePublicRuntimeConfig = { sanctum: ModuleOptions }
+export type ModuleRuntimeConfig = { sanctum: ModuleOptions }
+export type ModulePublicRuntimeConfig = { sanctum: PublicModuleOptions }
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -35,7 +36,13 @@ export default defineNuxtModule<ModuleOptions>({
     )
 
     _nuxt.options.build.transpile.push(resolver.resolve('./runtime'))
-    _nuxt.options.runtimeConfig.public.sanctum = sanctumConfig
+    _nuxt.options.runtimeConfig.sanctum = sanctumConfig
+
+    const publicSanctumConfig = { ...sanctumConfig }
+    // @ts-expect-error force delete non-optional key
+    delete publicSanctumConfig.serverProxy
+
+    _nuxt.options.runtimeConfig.public.sanctum = publicSanctumConfig
 
     const logger = useLogger(MODULE_NAME, {
       level: sanctumConfig.logLevel,

--- a/src/runtime/composables/useSanctumConfig.ts
+++ b/src/runtime/composables/useSanctumConfig.ts
@@ -1,6 +1,6 @@
-import type { ModuleOptions } from '../types/options'
+import type { PublicModuleOptions } from '../types/options'
 import { useRuntimeConfig } from '#imports'
 
-export const useSanctumConfig = (): ModuleOptions => {
-  return useRuntimeConfig().public.sanctum as ModuleOptions
+export const useSanctumConfig = (): PublicModuleOptions => {
+  return useRuntimeConfig().public.sanctum as PublicModuleOptions
 }

--- a/src/runtime/interceptors/request/stateful.ts
+++ b/src/runtime/interceptors/request/stateful.ts
@@ -1,7 +1,7 @@
 import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { useSanctumConfig } from '../../composables/useSanctumConfig'
-import type { ModuleOptions } from '../../types/options'
+import type { PublicModuleOptions } from '../../types/options'
 import { type NuxtApp, useCookie, useRequestHeaders, useRequestURL } from '#app'
 
 const SECURE_METHODS = new Set(['post', 'delete', 'put', 'patch'])
@@ -15,7 +15,7 @@ const COOKIE_OPTIONS: { readonly: true } = { readonly: true }
  */
 function useClientHeaders(
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): void {
   const clientHeaders = useRequestHeaders(['cookie', 'user-agent'])
@@ -44,7 +44,7 @@ function useClientHeaders(
  * @param logger Logger instance
  */
 async function initCsrfCookie(
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): Promise<void> {
   if (config.endpoints.csrf === undefined) {
@@ -67,7 +67,7 @@ async function initCsrfCookie(
  */
 async function useCsrfHeader(
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): Promise<void> {
   if (config.csrf.cookie === undefined) {

--- a/src/runtime/interceptors/response/validation.ts
+++ b/src/runtime/interceptors/response/validation.ts
@@ -1,9 +1,9 @@
 import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
-import type { ModuleOptions } from '../../types/options'
+import type { PublicModuleOptions } from '../../types/options'
 import { type NuxtApp, useRequestURL } from '#app'
 
-type HeaderValidator = (headers: Headers, config: ModuleOptions, logger: ConsolaInstance) => void
+type HeaderValidator = (headers: Headers, config: PublicModuleOptions, logger: ConsolaInstance) => void
 
 /**
  * Checks if the `set-cookie` header is present in the response headers.
@@ -13,7 +13,7 @@ type HeaderValidator = (headers: Headers, config: ModuleOptions, logger: Consola
  */
 const validateCookieHeader: HeaderValidator = (
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): void => {
   if (config.mode == 'token') {
@@ -33,7 +33,7 @@ const validateCookieHeader: HeaderValidator = (
  */
 const validateContentTypeHeader: HeaderValidator = (
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): void => {
   const contentType = headers.get('content-type')
@@ -56,7 +56,7 @@ const validateContentTypeHeader: HeaderValidator = (
  */
 const validateCredentialsHeader: HeaderValidator = (
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): void => {
   if (config.mode == 'token') {
@@ -78,7 +78,7 @@ const validateCredentialsHeader: HeaderValidator = (
  */
 const validateOriginHeader: HeaderValidator = (
   headers: Headers,
-  config: ModuleOptions,
+  config: PublicModuleOptions,
   logger: ConsolaInstance,
 ): void => {
   const allowOrigin = headers.get('access-control-allow-origin')
@@ -112,7 +112,7 @@ export async function validateResponseHeaders(
     return
   }
 
-  const config = app.$config.public.sanctum as ModuleOptions
+  const config = app.$config.public.sanctum as PublicModuleOptions
   const headers = ctx.response?.headers
 
   if (!headers) {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -4,7 +4,7 @@ import { createHttpClient } from './httpFactory'
 import { useSanctumUser } from './composables/useSanctumUser'
 import { useSanctumConfig } from './composables/useSanctumConfig'
 import { useSanctumAppConfig } from './composables/useSanctumAppConfig'
-import type { ModuleOptions } from './types/options'
+import type { PublicModuleOptions } from './types/options'
 import { IDENTITY_LOADED_KEY } from './utils/constants'
 import { useSanctumLogger } from './utils/logging'
 import { defineNuxtPlugin, updateAppConfig, useState, type NuxtApp } from '#app'
@@ -25,7 +25,7 @@ async function setupDefaultTokenStorage(nuxtApp: NuxtApp, logger: ConsolaInstanc
   })
 }
 
-async function initialIdentityLoad(nuxtApp: NuxtApp, client: $Fetch, options: ModuleOptions, logger: ConsolaInstance) {
+async function initialIdentityLoad(nuxtApp: NuxtApp, client: $Fetch, options: PublicModuleOptions, logger: ConsolaInstance) {
   const identityFetchedOnInit = useState<boolean>(
     IDENTITY_LOADED_KEY,
     () => false,

--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -6,15 +6,16 @@ import {
 } from 'h3'
 import { defineEventHandler, getRequestHeaders, readBody, getQuery, setResponseStatus } from 'h3'
 import { $fetch } from 'ofetch'
-import { useSanctumConfig } from '../../composables/useSanctumConfig'
 import { useSanctumLogger } from '../../utils/logging'
 import { determineCredentialsMode } from '../../utils/credentials'
+import type { ModuleOptions } from '../../types/options'
+import { useRuntimeConfig } from '#imports'
 
 const METHODS_WITH_BODY: HTTPMethod[] = ['POST', 'PUT', 'PATCH', 'DELETE']
 const HEADERS_TO_IGNORE = ['content-length', 'content-encoding', 'transfer-encoding']
 
 export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
-  const config = useSanctumConfig()
+  const config = useRuntimeConfig().sanctum as ModuleOptions
   const logger = useSanctumLogger(config.logLevel)
 
   const

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -137,7 +137,7 @@ export interface ServerProxy {
 /**
  * Options to be passed to the plugin.
  */
-export interface ModuleOptions {
+export interface PublicModuleOptions {
   /**
    * The base URL of the Laravel API.
    * @default 'http://localhost:80'
@@ -209,6 +209,9 @@ export interface ModuleOptions {
    * @see https://nuxt.com/docs/api/kit/plugins#options
    */
   appendPlugin: boolean
+}
+
+export interface ModuleOptions extends PublicModuleOptions {
   /**
    * Server API proxy configuration to handle Laravel requests on SSR-side first.
    */


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention the issues.**

Closes #393 by moving `serverProxy` from `public` to `runtime` config part and hiding it from the client payload.
