### PR TITLE
fix: resolve reactive options in useAsyncData

### DIFF
--- a/src/runtime/composables/useLazySanctumFetch.ts
+++ b/src/runtime/composables/useLazySanctumFetch.ts
@@ -6,7 +6,7 @@ import type { NuxtError } from '#app'
 
 export function useLazySanctumFetch<ResT, NuxtErrorDataT = unknown, DataT = ResT, PickKeys extends KeysOf<DataT> = KeysOf<DataT>, DefaultT = undefined>(
   url: string,
-  options?: SanctumFetchOptions,
+  options?: SanctumFetchOptions | (() => SanctumFetchOptions),
   asyncDataOptions?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>,
   key?: string,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined> {
@@ -15,7 +15,10 @@ export function useLazySanctumFetch<ResT, NuxtErrorDataT = unknown, DataT = ResT
 
   return useLazyAsyncData<ResT, NuxtErrorDataT, DataT, PickKeys, DefaultT>(
     fetchKey,
-    () => client<ResT>(url, options as SanctumFetchOptions<'json'>),
+    () => {
+      const resolvedOptions = typeof options == 'function' ? options() : options
+      return client<ResT>(url, resolvedOptions as SanctumFetchOptions<'json'>)
+    },
     asyncDataOptions,
   )
 }

--- a/src/runtime/composables/useSanctumFetch.ts
+++ b/src/runtime/composables/useSanctumFetch.ts
@@ -6,7 +6,7 @@ import type { NuxtError } from '#app'
 
 export function useSanctumFetch<ResT, NuxtErrorDataT = unknown, DataT = ResT, PickKeys extends KeysOf<DataT> = KeysOf<DataT>, DefaultT = undefined>(
   url: string,
-  options?: SanctumFetchOptions,
+  options?: SanctumFetchOptions | (() => SanctumFetchOptions),
   asyncDataOptions?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
   key?: string,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined> {
@@ -15,7 +15,10 @@ export function useSanctumFetch<ResT, NuxtErrorDataT = unknown, DataT = ResT, Pi
 
   return useAsyncData<ResT, NuxtErrorDataT, DataT, PickKeys, DefaultT>(
     fetchKey,
-    () => client<ResT>(url, options as SanctumFetchOptions<'json'>),
+    () => {
+      const clientOptions = typeof options == 'function' ? options() : options
+      return client<ResT>(url, clientOptions as SanctumFetchOptions<'json'>)
+    },
     asyncDataOptions,
   )
 }

--- a/src/runtime/utils/fetch.ts
+++ b/src/runtime/utils/fetch.ts
@@ -9,18 +9,19 @@ import type { SanctumFetchOptions } from '../types/fetch'
 export function assembleFetchRequestKey(
   url: string,
   lazy: boolean,
-  options?: SanctumFetchOptions,
+  options?: SanctumFetchOptions | (() => SanctumFetchOptions),
 ): string {
   const operation = lazy ? 'lazy-fetch' : 'fetch'
+  const resolvedOptions = typeof options == 'function' ? options() : options
 
   const parts = [
     'sanctum',
     operation,
     url,
-    options?.method ?? 'get',
+    resolvedOptions?.method ?? 'get',
     JSON.stringify({
-      query: options?.query ?? {},
-      body: options?.body ?? {},
+      query: resolvedOptions?.query ?? {},
+      body: resolvedOptions?.body ?? {},
     }),
   ]
 


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Fixes #429 by resolving reactive options during fetch request rather than composable initialisation.
