### PR TITLE
fix(proxy): use runtime-agnostic readBody for v8-engine compatibility

### DIFF
--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -1,4 +1,4 @@
-import { appendResponseHeader, defineEventHandler, getRequestHeaders, getQuery, setResponseStatus } from 'h3'
+import { appendResponseHeader, defineEventHandler, getRequestHeaders, getQuery, setResponseStatus, readBody } from 'h3'
 import type { H3Event, EventHandlerRequest, HTTPMethod } from 'h3'
 import { $fetch, type FetchResponse, type FetchContext } from 'ofetch'
 import { useSanctumLogger } from '../../utils/logging'
@@ -38,7 +38,7 @@ async function proxyRequest(event: H3Event<EventHandlerRequest>, endpoint: strin
   const
     method = event.method,
     query = getQuery(event),
-    body = METHODS_WITH_BODY.includes(method) ? event.node.req : undefined,
+    body = METHODS_WITH_BODY.includes(method) ? await readBody(event) : undefined,
     headers = {
       accept: 'application/json',
       ...getRequestHeaders(event),


### PR DESCRIPTION
Fixes issue #487 

This PR replaces `event.node.req` with h3's `readBody(event)` in server proxy to support all runtimes.

## Problem
The proxy used `event.node.req` to read request bodies, which only works in Node.js runtime. Cloudflare Pages uses Workers/V8 runtime, causing bodies to be undefined and breaking authentication and all payloads sent with the proxy enabled.

Fixed the above issue to support `readBody` that works across all platforms: Node.js, Cloudflare Workers, Vercel Edge, etc.

Breaking/Compatibility with Module version:-
- maintains backward compatibility with Node.js
- enables support for all edge runtimes
- This is not a breaking change for v2 of the module