### PR TITLE
fix: do not read body on multipart requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vue": "^3.5.26",
     "vue-tsc": "^3.2.2"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

This should resolve #502 by returning Node-specific requests instead of reading the body when FormData is passed as a payload. However, this might be incompatible with non-node environments like Cloudflare Workers and others.

Potentially, this should be fixed in the following Nuxt versions if they switch to H3 v2 with `event.request` support.
