### PR TITLE
Docs fix: Add missing parentheses

### DIFF
--- a/docs/content/6.advanced/1.interceptors.md
+++ b/docs/content/6.advanced/1.interceptors.md
@@ -37,7 +37,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hook('sanctum:response', (app, ctx, logger) => {
     logger.info('Sanctum response hook triggered', ctx.request)
   })
-}
+})
 ```
 
 Each interceptor receives 3 arguments:

--- a/docs/content/6.advanced/5.dependencies.md
+++ b/docs/content/6.advanced/5.dependencies.md
@@ -18,7 +18,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       .headers
       .set("X-Language", app.$i18n.localeProperties.value.code)
   })
-}
+})
 ```
 
 Since this module cannot know about its dependencies in your application, 


### PR DESCRIPTION
Noticed some pages didn't have the ending parentheses in code example. 