### PR TITLE
fix(proxy): prevent readBody crash on empty DELETE requests in Cloudflare Workers

### DIFF
--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -36,13 +36,13 @@ async function proxyRequest(event: H3Event<EventHandlerRequest>, endpoint: strin
   const nitroApp = useNitroApp()
 
   const
-      method = event.method,
-      query = getQuery(event),
-      body = await getBody(event),
-      headers = {
-        accept: 'application/json',
-        ...getRequestHeaders(event),
-      }
+    method = event.method,
+    query = getQuery(event),
+    body = await getBody(event),
+    headers = {
+      accept: 'application/json',
+      ...getRequestHeaders(event),
+    }
 
   return await $fetch.raw(endpoint, {
     method: method,


### PR DESCRIPTION
Fixes #515 

This PR fixes a critical bug where DELETE requests fail with a 500 error when the application is deployed to Cloudflare Workers using the `serverProxy` mode.

**The Possible Issue:**
- The proxy server includes DELETE in the `METHODS_WITH_BODY` array
- It attempts to call `readBody(event)` for all DELETE requests
- Most DELETE requests have no body (Content-Length: 0 or missing)
- On Cloudflare Workers v8 runtime, calling `readBody(event)` on an empty body seem to be throwing an exception and crashes the worker

**Fix:**
- Check the `Content-Length` header before attempting to read the request body
- If `Content-Length` is 0, not set, or missing, return `undefined` without calling `readBody(event)`
- This prevents the v8 runtime exception while maintaining compatibility with DELETE requests that do have a body