### PR TITLE
feat: sanitize proxy request headers to exclude hop-by-hop

### DIFF
--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -11,7 +11,7 @@ import {
 import { $fetch, type FetchContext, type FetchResponse } from 'ofetch'
 import { useSanctumLogger } from '../../utils/logging'
 import { determineCredentialsMode } from '../../utils/credentials'
-import { trimTrailingSlash } from '../utils/formatter'
+import { trimTrailingSlash } from '../../utils/formatter'
 import type { ModuleOptions } from '../../types/options'
 import { useRuntimeConfig } from '#imports'
 import type { ConsolaInstance } from 'consola'


### PR DESCRIPTION
### Problem
When `serverProxy` is enabled, the module forwards incoming request headers verbatim to `$fetch` (undici).
If the browser / reverse proxy sends hop-by-hop headers (e.g. `connection: upgrade`), undici throws:
`UND_ERR_INVALID_ARG: invalid connection header`, resulting in `<no response> fetch failed`.

### Changes
- Strip hop-by-hop headers (`connection`, `upgrade`, `keep-alive`, `transfer-encoding`, etc.) before proxying.
- Also drop `host` and `content-length` to let undici compute them correctly.
- (Optional) Drop `accept-encoding` to avoid compression-related proxy issues.

### Reproduction
1. Enable `serverProxy`.
2. Send a request containing `connection: upgrade` to the proxy route.
3. Observe undici error `invalid connection header`.

### Expected
Proxy should forward request to upstream and return upstream response.