### PR TITLE
fix(proxy): use runtime-agnostic getRequestWebStream for multipart file uploads

### DIFF
--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -5,8 +5,8 @@ import {
   getQuery,
   getRequestHeader,
   getRequestHeaders,
+  getRequestWebStream,
   readBody,
-  readRawBody,
   setResponseStatus,
 } from 'h3'
 import { $fetch, type FetchContext, type FetchResponse } from 'ofetch'
@@ -119,7 +119,7 @@ async function getBody(event: H3Event<EventHandlerRequest>) {
   const contentType = getRequestHeader(event, 'content-type')
 
   if (contentType?.includes('multipart/form-data')) {
-    return await readRawBody(event, false)
+    return getRequestWebStream(event)
   }
 
   return readBody(event)

--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -6,6 +6,7 @@ import {
   getRequestHeader,
   getRequestHeaders,
   readBody,
+  readRawBody,
   setResponseStatus,
 } from 'h3'
 import { $fetch, type FetchContext, type FetchResponse } from 'ofetch'
@@ -118,7 +119,7 @@ async function getBody(event: H3Event<EventHandlerRequest>) {
   const contentType = getRequestHeader(event, 'content-type')
 
   if (contentType?.includes('multipart/form-data')) {
-    return Promise.resolve(event.node.req)
+    return await readRawBody(event, false)
   }
 
   return readBody(event)


### PR DESCRIPTION
Related to Issue #487

File uploads via proxy mode (`multipart/form-data`) crash on Cloudflare Workers / serverless environments because the code uses `event.node.req`, a Node.js-specific API that doesn't exist on the V8 runtime.