### PR TITLE
docs: clarify SSR environment variable requirements for baseUrl

### DIFF
--- a/docs/content/2.usage/1.configuration.md
+++ b/docs/content/2.usage/1.configuration.md
@@ -157,10 +157,18 @@ The following options are only available on the server-side:
 It is possible to override options via environment variables too. 
 It might be useful when you want to use `.env` file to provide baseUrl for Laravel API.
 
-And here is what it will look like in `.env` file:
+::warning
+If you are using SSR (Server-Side Rendering) and relying *entirely* on `.env` files rather than hardcoding the `baseUrl` in your `nuxt.config.ts`, you **must** provide both the public and private environment variables. Otherwise, the server-side fetch will fall back to the default `http://localhost:80`.
+::
+
+Here is what it should look like in your `.env` file:
 
 ```env [.env]
-NUXT_PUBLIC_SANCTUM_BASE_URL='http://localhost:80'
+# Used by the browser (CSR)
+NUXT_PUBLIC_SANCTUM_BASE_URL='http://localhost:8000'
+
+# Used by the Nuxt server (SSR)
+NUXT_SANCTUM_BASE_URL='http://localhost:8000'
 ```
 
 ## Configuration example

--- a/docs/content/2.usage/1.configuration.md
+++ b/docs/content/2.usage/1.configuration.md
@@ -158,7 +158,7 @@ It is possible to override options via environment variables too.
 It might be useful when you want to use `.env` file to provide baseUrl for Laravel API.
 
 ::warning
-If you are using SSR (Server-Side Rendering) and relying *entirely* on `.env` files rather than hardcoding the `baseUrl` in your `nuxt.config.ts`, you **must** provide both the public and private environment variables. Otherwise, the server-side fetch will fall back to the default `http://localhost:80`.
+If you are using SSR (Server-Side Rendering) and relying *entirely* on `.env` files rather than hardcoding the `baseUrl` in your `nuxt.config.ts`, you **must** provide both the public and private environment variables. Otherwise, the server-side fetch will not see the public variable and the page will hang indefinitely with an infinite loop of SSR requests.
 ::
 
 Here is what it should look like in your `.env` file:

--- a/docs/content/6.advanced/7.troubleshooting.md
+++ b/docs/content/6.advanced/7.troubleshooting.md
@@ -100,15 +100,11 @@ Also, while working locally with enabled SSL, you may face the following error:
 
 To enable HTTPS protocol, you might need to set an environment variable `NODE_TLS_REJECT_UNAUTHORIZED=0`.
 
-### SSR request hits port 80 and returns 404 (Redirects to Login on full page reload)
+### Page hangs on load with infinite SSR requests when using only NUXT_PUBLIC_SANCTUM_BASE_URL
 
-If your app works perfectly during client-side navigation (CSR), but a hard refresh (SSR) redirects you to the login page, and your terminal logs show an error like:
+If your app never finishes loading and your terminal shows an infinite loop of SSR plugin setup and requests to your base URL with no response, this is likely the cause.
 
-```text
-[nuxt-auth-sanctum:ssr]  ERROR  Unable to load user identity from API [GET] "http://localhost:80/api/user": <no response> fetch failed
-```
-
-This happens because you defined your API URL in your `.env` file using **only** `NUXT_PUBLIC_SANCTUM_BASE_URL`. Nuxt strictly isolates public and private runtime configurations. When the server attempts to fetch your user identity during SSR, it cannot see the public variable and falls back to the default `http://localhost:80`.
+This happens because you defined your API URL in your `.env` file using **only** `NUXT_PUBLIC_SANCTUM_BASE_URL`. Nuxt strictly isolates public and private runtime configurations. When the server attempts to fetch your user identity during SSR, it cannot see the public variable and the request never resolves.
 
 **Fix:** Add `NUXT_SANCTUM_BASE_URL=http://your-api-url` to your `.env` file alongside the public one to ensure the server context uses the correct URL.
 

--- a/docs/content/6.advanced/7.troubleshooting.md
+++ b/docs/content/6.advanced/7.troubleshooting.md
@@ -100,6 +100,18 @@ Also, while working locally with enabled SSL, you may face the following error:
 
 To enable HTTPS protocol, you might need to set an environment variable `NODE_TLS_REJECT_UNAUTHORIZED=0`.
 
+### SSR request hits port 80 and returns 404 (Redirects to Login on full page reload)
+
+If your app works perfectly during client-side navigation (CSR), but a hard refresh (SSR) redirects you to the login page, and your terminal logs show an error like:
+
+```text
+[nuxt-auth-sanctum:ssr]  ERROR  Unable to load user identity from API [GET] "http://localhost:80/api/user": <no response> fetch failed
+```
+
+This happens because you defined your API URL in your `.env` file using **only** `NUXT_PUBLIC_SANCTUM_BASE_URL`. Nuxt strictly isolates public and private runtime configurations. When the server attempts to fetch your user identity during SSR, it cannot see the public variable and falls back to the default `http://localhost:80`.
+
+**Fix:** Add `NUXT_SANCTUM_BASE_URL=http://your-api-url` to your `.env` file alongside the public one to ensure the server context uses the correct URL.
+
 ### User is not authenticated on plugin initialization (Code 401)
 
 With enabled logging, you can check your Nuxt logs to find errors and warnings about the reason for the 401 response. 

--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -5,8 +5,8 @@ import {
   getQuery,
   getRequestHeader,
   getRequestHeaders,
+  getRequestWebStream,
   readBody,
-  readRawBody,
   setResponseStatus,
 } from 'h3'
 import { $fetch, type FetchContext, type FetchResponse } from 'ofetch'
@@ -119,7 +119,7 @@ async function getBody(event: H3Event<EventHandlerRequest>) {
   const contentType = getRequestHeader(event, 'content-type')
 
   if (contentType?.includes('multipart/form-data')) {
-    return await readRawBody(event, false)
+    return getRequestWebStream(event)
   }
 
   return readBody(event)

--- a/src/runtime/server/api/proxy.ts
+++ b/src/runtime/server/api/proxy.ts
@@ -6,6 +6,7 @@ import {
   getRequestHeader,
   getRequestHeaders,
   readBody,
+  readRawBody,
   setResponseStatus,
 } from 'h3'
 import { $fetch, type FetchContext, type FetchResponse } from 'ofetch'
@@ -118,7 +119,7 @@ async function getBody(event: H3Event<EventHandlerRequest>) {
   const contentType = getRequestHeader(event, 'content-type')
 
   if (contentType?.includes('multipart/form-data')) {
-    return Promise.resolve(event.node.req)
+    return await readRawBody(event, false)
   }
 
   return readBody(event)


### PR DESCRIPTION
Closes #594

This PR updates the documentation to address an issue where configuring the module's `baseUrl` strictly via `.env` with only `NUXT_PUBLIC_SANCTUM_BASE_URL` causes SSR to break.

Because Nuxt strictly isolates `runtimeConfig.public` from the private `runtimeConfig` at runtime, the server context never sees the public env var. The private `config.sanctum.baseUrl` keeps whatever value was baked at build time, causing the SSR fetch to loop indefinitely and the page never loads while the terminal logs show continuous requests with no resolution.