### PR TITLE
fix: use correct config in logger and improve docs about env overrides

### DIFF
--- a/docs/content/2.usage/1.configuration.md
+++ b/docs/content/2.usage/1.configuration.md
@@ -171,6 +171,31 @@ NUXT_PUBLIC_SANCTUM_BASE_URL='http://localhost:8000'
 NUXT_SANCTUM_BASE_URL='http://localhost:8000'
 ```
 
+::warning
+The `origin` option requires a static default in `nuxt.config.ts` for environment
+variables to work. Unlike other options, Nuxt ignores env var overrides for keys
+that are `undefined` by default.
+
+```typescript
+sanctum: {
+    origin: 'http://localhost:3000', // Set static default first
+}
+```
+
+Then in your `.env`:
+```env
+# For client-side (CSR)
+NUXT_PUBLIC_SANCTUM_ORIGIN=https://your-domain.com
+
+# For server-side (SSR)
+NUXT_SANCTUM_ORIGIN=https://your-domain.com
+```
+
+Note: `NUXT_PUBLIC_SANCTUM_ORIGIN` only affects client-side, while `NUXT_SANCTUM_ORIGIN`
+only affects server-side.
+::
+
+
 ## Configuration example
 
 Here is an example of a full module configuration

--- a/src/runtime/interceptors/response/validation.ts
+++ b/src/runtime/interceptors/response/validation.ts
@@ -4,6 +4,7 @@ import type { PublicModuleOptions } from '../../types/options'
 import { useRequestURL } from '#app'
 import type { NuxtApp } from '#app'
 import { isServerRuntime } from '../../utils/runtime'
+import { useSanctumConfig } from '../../composables/useSanctumConfig'
 
 type HeaderValidator = (headers: Headers, config: PublicModuleOptions, logger: ConsolaInstance) => void
 
@@ -114,7 +115,7 @@ export async function validateResponseHeaders(
     return
   }
 
-  const config = app.$config.public.sanctum as PublicModuleOptions
+  const config = useSanctumConfig()
   const headers = ctx.response?.headers
 
   if (!headers) {

--- a/test/unit/interceptors/request/params.test.ts
+++ b/test/unit/interceptors/request/params.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setRequestParams } from '../../../../src/runtime/interceptors/request/params'
-import { createMock } from '../../../helpers/mocks'
+import { createAppMock, createLoggerMock, createMock } from '../../../helpers/mocks'
 import type { FetchContext } from 'ofetch'
-import type { NuxtApp } from '#app'
-import type { ConsolaInstance } from 'consola'
 
 describe('request interceptors', () => {
   beforeEach(() => {
@@ -12,8 +10,8 @@ describe('request interceptors', () => {
 
   describe('setRequestParams', () => {
     it('sets application/json accept header if not set', async () => {
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         options: {
@@ -29,8 +27,8 @@ describe('request interceptors', () => {
     })
 
     it('does not override existing accept header', async () => {
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         options: {
@@ -46,8 +44,8 @@ describe('request interceptors', () => {
     })
 
     it('updates FormData body on PUT requests', async () => {
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const formData = new FormData()
       formData.append('name', 'test')
@@ -68,8 +66,8 @@ describe('request interceptors', () => {
     })
 
     it('does not modify non-FormData PUT body', async () => {
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         options: {

--- a/test/unit/interceptors/response/errorHandler.test.ts
+++ b/test/unit/interceptors/response/errorHandler.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handleResponseError } from '../../../../src/runtime/interceptors/response/errorHandler'
-import { createMock } from '../../../helpers/mocks'
+import { createAppMock, createLoggerMock, createMock } from '../../../helpers/mocks'
 import { TEST_CONFIG } from '../../../helpers/constants'
-import type { NuxtApp } from '#app'
-import type { ConsolaInstance } from 'consola'
 import type { FetchContext } from 'ofetch'
 
 const {
@@ -44,8 +42,8 @@ describe('response interceptors', () => {
 
   describe('handleResponseError', () => {
     it('writes warning on 419 response', async () => {
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
       const ctx = createMock<FetchContext>({ response: { status: 419 } })
 
       await handleResponseError(mockApp, ctx, mockLogger)
@@ -58,8 +56,8 @@ describe('response interceptors', () => {
 
       useSanctumUserMock.mockReturnValue(mockUser)
 
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
       const ctx = createMock<FetchContext>({ response: { status: 401 } })
 
       await handleResponseError(mockApp, ctx, mockLogger)
@@ -73,8 +71,8 @@ describe('response interceptors', () => {
 
       useSanctumUserMock.mockReturnValue(mockUser)
 
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
       const ctx = createMock<FetchContext>({ response: { status: 401 } })
 
       await handleResponseError(mockApp, ctx, mockLogger)
@@ -93,12 +91,8 @@ describe('response interceptors', () => {
 
       isServerRuntimeMock.mockReturnValue(false)
 
-      const mockApp = createMock<NuxtApp>({
-        callHook: vi.fn().mockResolvedValue(undefined),
-        runWithContext: vi.fn(fn => fn()),
-      })
-
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
       const ctx = createMock<FetchContext>({ response: { status: 401 } })
 
       await handleResponseError(mockApp, ctx, mockLogger)
@@ -117,12 +111,8 @@ describe('response interceptors', () => {
 
       isServerRuntimeMock.mockReturnValue(true)
 
-      const mockApp = createMock<NuxtApp>({
-        callHook: vi.fn(),
-        runWithContext: vi.fn(fn => fn()),
-      })
-
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({ response: { status: 401 } })
 
@@ -138,8 +128,8 @@ describe('response interceptors', () => {
 
       useSanctumUserMock.mockReturnValue(mockUser)
 
-      const mockApp = createMock<NuxtApp>()
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({ response: { status: 500 } })
 

--- a/test/unit/interceptors/response/validation.test.ts
+++ b/test/unit/interceptors/response/validation.test.ts
@@ -1,18 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { validateResponseHeaders } from '../../../../src/runtime/interceptors/response/validation'
-import { createMock } from '../../../helpers/mocks'
+import { createAppMock, createLoggerMock, createMock } from '../../../helpers/mocks'
 import { TEST_CONFIG, COMMON_HEADERS } from '../../../helpers/constants'
-import type { NuxtApp } from '#app'
-import type { ConsolaInstance } from 'consola'
 import type { FetchContext } from 'ofetch'
 
 const {
   isServerRuntimeMock,
   useRequestURLMock,
+  useRuntimeConfigMock,
 } = vi.hoisted(() => {
   return {
     isServerRuntimeMock: vi.fn(),
     useRequestURLMock: vi.fn(),
+    useRuntimeConfigMock: vi.fn(),
   }
 })
 
@@ -26,6 +26,11 @@ vi.mock(
   () => ({ useRequestURL: useRequestURLMock }),
 )
 
+vi.mock(
+  '#imports',
+  () => ({ useRuntimeConfig: useRuntimeConfigMock }),
+)
+
 describe('response interceptors', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -35,8 +40,8 @@ describe('response interceptors', () => {
     it('skips validation in CSR mode', async () => {
       isServerRuntimeMock.mockReturnValue(false)
 
-      const mockApp = createMock<NuxtApp>({})
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({})
 
@@ -47,16 +52,12 @@ describe('response interceptors', () => {
 
     it('writes warning log on empty headers', async () => {
       isServerRuntimeMock.mockReturnValue(true)
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {},
-          },
-        },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {},
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({})
 
@@ -68,18 +69,14 @@ describe('response interceptors', () => {
     it('passes validation when all headers are present', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'token',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -100,18 +97,14 @@ describe('response interceptors', () => {
     it('writes warning if cookie header is missing [cookie mode]', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -131,18 +124,14 @@ describe('response interceptors', () => {
     it('does not validate cookie header [token mode]', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'token',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'token',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -162,18 +151,14 @@ describe('response interceptors', () => {
     it('writes warning if content-type header is missing', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -193,18 +178,14 @@ describe('response interceptors', () => {
     it('writes debug if content-type header is not JSON', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ debug: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -219,24 +200,21 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.debug).toHaveBeenCalledWith(`[response] 'content-type' is present in response but different (expected: application/json, got: unknown)`)
     })
 
     it('writes warning if credentials header is missing [cookie mode]', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -250,24 +228,21 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).toHaveBeenCalledWith(`[response] 'access-control-allow-credentials' header is missing or invalid (expected: true, got: null)`)
     })
 
     it('writes warning if credentials header is disabled [cookie mode]', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -282,24 +257,21 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).toHaveBeenCalledWith(`[response] 'access-control-allow-credentials' header is missing or invalid (expected: true, got: false)`)
     })
 
     it('skips validation of credentials header [token mode]', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'token',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'token',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -313,24 +285,21 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).not.toHaveBeenCalled()
     })
 
     it('writes warning if origin header is missing', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -344,24 +313,21 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).toHaveBeenCalledWith(`[response] 'access-control-allow-origin' header is missing or invalid (expected: ${TEST_CONFIG.CUSTOM_ORIGIN}, got: null)`)
     })
 
     it('writes warning if origin header does not include request origin', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
-
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-            },
-          },
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -376,25 +342,28 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).toHaveBeenCalledWith(`[response] 'access-control-allow-origin' header is missing or invalid (expected: ${TEST_CONFIG.CUSTOM_ORIGIN}, got: http://another-host.dev)`)
     })
 
     it('writes warning if origin header does not include origin from config', async () => {
       isServerRuntimeMock.mockReturnValue(true)
       useRequestURLMock.mockReturnValue({ origin: TEST_CONFIG.CUSTOM_ORIGIN })
+      useRuntimeConfigMock.mockReturnValue({
+        sanctum: {
+          mode: 'cookie',
+          origin: 'http://sanctum-host.dev',
+        },
 
-      const mockApp = createMock<NuxtApp>({
-        $config: {
-          public: {
-            sanctum: {
-              mode: 'cookie',
-              origin: 'http://sanctum-host.dev',
-            },
+        public: {
+          sanctum: {
+            origin: 'http://client-sanctum-host.dev',
           },
         },
       })
 
-      const mockLogger = createMock<ConsolaInstance>({ warn: vi.fn() })
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
 
       const ctx = createMock<FetchContext>({
         response: {
@@ -409,6 +378,7 @@ describe('response interceptors', () => {
 
       await validateResponseHeaders(mockApp, ctx, mockLogger)
 
+      expect(useRuntimeConfigMock).toHaveBeenCalled()
       expect(mockLogger.warn).toHaveBeenCalledWith(`[response] 'access-control-allow-origin' header is missing or invalid (expected: http://sanctum-host.dev, got: http://another-host.dev)`)
     })
   })


### PR DESCRIPTION
**Describe the problem and solution**

Closes #604 .

- use correct `origin` in the logger message (csr vs ssr)
- added a note to the docs about `origin` override with `undefined`
- improved test coverage to reflect the changes
