### PR TITLE
fix: handle origin and referrer in any mode

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -31,8 +31,28 @@ jobs:
         run: pnpm lint
       - name: Type check
         run: pnpm test:types
-  test:
+  test-unit:
     runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.node_version }}
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build stubs
+        run: pnpm dev:prepare
+      - name: Test [unit, nuxt]
+        run: pnpm test --project=unit --project=nuxt
+  test-e2e:
+    runs-on: ubuntu-latest
+    needs: test-unit
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,5 +69,5 @@ jobs:
         run: pnpm dev:prepare
       - name: Install Playwright
         run: pnpm exec playwright install chromium --with-deps
-      - name: Test
-        run: pnpm test
+      - name: Test [e2e]
+        run: pnpm test --project=e2e

--- a/src/runtime/interceptors/index.ts
+++ b/src/runtime/interceptors/index.ts
@@ -1,6 +1,7 @@
 import type { SanctumInterceptor } from '../types/config'
 import { setRequestParams } from './request/params'
 import { setStatefulParams } from './request/stateful'
+import { setRequestOrigin } from './request/cors'
 import { setTokenHeader } from './request/token'
 import { logRequestHeaders } from './request/logging'
 import { proxyResponseHeaders } from './response/proxy'
@@ -11,6 +12,7 @@ import { handleResponseError } from './response/errorHandler'
 const [request, response, responseError] = [
   [
     setRequestParams,
+    setRequestOrigin,
     setStatefulParams,
     setTokenHeader,
     logRequestHeaders,

--- a/src/runtime/interceptors/request/cors.ts
+++ b/src/runtime/interceptors/request/cors.ts
@@ -1,0 +1,34 @@
+import { useRequestURL, type NuxtApp } from '#app'
+import type { ConsolaInstance } from 'consola'
+import type { FetchContext } from 'ofetch'
+import { isServerRuntime } from '../../utils/runtime'
+import { useSanctumConfig } from '../../composables/useSanctumConfig'
+
+/**
+ * Handle origin/referrer headers for the request
+ * @param _app Nuxt application instance
+ * @param ctx Fetch context
+ * @param logger Module logger instance
+ */
+export async function setRequestOrigin(_app: NuxtApp, ctx: FetchContext, logger: ConsolaInstance) {
+  if (!isServerRuntime()) {
+    return
+  }
+
+  const config = useSanctumConfig()
+  const origin = config.origin ?? useRequestURL().origin
+
+  const headersToAdd = {
+    Referer: origin,
+    Origin: origin,
+  }
+
+  for (const [key, value] of Object.entries(headersToAdd)) {
+    ctx.options.headers.set(key, value)
+  }
+
+  logger.debug(
+    '[request] added origin headers to server request',
+    Object.keys(headersToAdd),
+  )
+}

--- a/src/runtime/interceptors/request/stateful.ts
+++ b/src/runtime/interceptors/request/stateful.ts
@@ -2,7 +2,7 @@ import type { FetchContext } from 'ofetch'
 import type { ConsolaInstance } from 'consola'
 import { useSanctumConfig } from '../../composables/useSanctumConfig'
 import type { PublicModuleOptions } from '../../types/options'
-import { useCookie, useRequestHeaders, useRequestURL, refreshCookie, type NuxtApp } from '#app'
+import { useCookie, useRequestHeaders, refreshCookie, type NuxtApp } from '#app'
 import { isServerRuntime } from '../../utils/runtime'
 
 const SECURE_METHODS = new Set(['post', 'delete', 'put', 'patch'])
@@ -20,11 +20,8 @@ function useClientHeaders(
   logger: ConsolaInstance,
 ): void {
   const clientHeaders = useRequestHeaders(['cookie', 'user-agent'])
-  const origin = config.origin ?? useRequestURL().origin
 
   const headersToAdd = {
-    Referer: origin,
-    Origin: origin,
     ...(clientHeaders.cookie && { Cookie: clientHeaders.cookie }),
     ...(clientHeaders['user-agent'] && { 'User-Agent': clientHeaders['user-agent'] }),
   }

--- a/test/unit/interceptors/request/cors.test.ts
+++ b/test/unit/interceptors/request/cors.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setRequestOrigin } from '../../../../src/runtime/interceptors/request/cors'
+import { createAppMock, createLoggerMock, createMock } from '../../../helpers/mocks'
+import type { FetchContext } from 'ofetch'
+
+const {
+  useSanctumConfigMock,
+  isServerRuntimeMock,
+  useRequestURLMock,
+} = vi.hoisted(() => {
+  return {
+    useSanctumConfigMock: vi.fn(),
+    isServerRuntimeMock: vi.fn(),
+    useRequestURLMock: vi.fn(),
+  }
+})
+
+vi.mock(
+  '../../../../src/runtime/composables/useSanctumConfig',
+  () => ({ useSanctumConfig: useSanctumConfigMock }),
+)
+
+vi.mock(
+  '../../../../src/runtime/utils/runtime',
+  () => ({ isServerRuntime: isServerRuntimeMock.mockReturnValue(true) }),
+)
+
+vi.mock(
+  '#app',
+  () => ({
+    useRequestURL: useRequestURLMock,
+  }),
+)
+
+describe('request interceptors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  describe('setRequestOrigin', () => {
+    it('no-op when client request is CSR', async () => {
+      isServerRuntimeMock.mockReturnValue(false)
+
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
+
+      const ctx = createMock<FetchContext>({})
+
+      await setRequestOrigin(mockApp, ctx, mockLogger)
+
+      expect(isServerRuntimeMock).toHaveBeenCalled()
+      expect(mockLogger.debug).not.toHaveBeenCalled()
+    })
+
+    it('appends client headers in SSR [origin, referrer]', async () => {
+      useSanctumConfigMock.mockReturnValue({
+        origin: 'http://custom-origin.dev',
+      })
+      isServerRuntimeMock.mockReturnValue(true)
+
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
+
+      const ctx = createMock<FetchContext>({
+        options: {
+          method: undefined,
+          headers: new Headers(),
+        },
+      })
+
+      await setRequestOrigin(mockApp, ctx, mockLogger)
+
+      expect(ctx.options.headers).toStrictEqual(
+        new Headers({
+          Referer: 'http://custom-origin.dev',
+          Origin: 'http://custom-origin.dev',
+        }),
+      )
+
+      expect(isServerRuntimeMock).toHaveBeenCalled()
+      expect(useRequestURLMock).not.toHaveBeenCalled()
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[request] added origin headers to server request',
+        ['Referer', 'Origin'],
+      )
+    })
+
+    it('appends request origin if not provided', async () => {
+      useSanctumConfigMock.mockReturnValue({})
+      isServerRuntimeMock.mockReturnValue(true)
+      useRequestURLMock.mockReturnValue({ origin: 'http://custom-origin.dev' })
+
+      const mockApp = createAppMock()
+      const mockLogger = createLoggerMock()
+
+      const ctx = createMock<FetchContext>({
+        options: {
+          method: undefined,
+          headers: new Headers(),
+        },
+      })
+
+      await setRequestOrigin(mockApp, ctx, mockLogger)
+
+      expect(ctx.options.headers).toStrictEqual(
+        new Headers({
+          Referer: 'http://custom-origin.dev',
+          Origin: 'http://custom-origin.dev',
+        }),
+      )
+
+      expect(isServerRuntimeMock).toHaveBeenCalled()
+      expect(useRequestURLMock).toHaveBeenCalled()
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        '[request] added origin headers to server request',
+        ['Referer', 'Origin'],
+      )
+    })
+  })
+})

--- a/test/unit/interceptors/request/stateful.test.ts
+++ b/test/unit/interceptors/request/stateful.test.ts
@@ -7,7 +7,6 @@ const {
   useSanctumConfigMock,
   isServerRuntimeMock,
   useRequestHeadersMock,
-  useRequestURLMock,
   useCookieMock,
   refreshCookieMock,
   fetchMock,
@@ -16,7 +15,6 @@ const {
     useSanctumConfigMock: vi.fn(),
     isServerRuntimeMock: vi.fn(),
     useRequestHeadersMock: vi.fn(),
-    useRequestURLMock: vi.fn(),
     useCookieMock: vi.fn(),
     refreshCookieMock: vi.fn(),
     fetchMock: vi.fn(),
@@ -37,7 +35,6 @@ vi.mock(
   '#app',
   () => ({
     useRequestHeaders: useRequestHeadersMock,
-    useRequestURL: useRequestURLMock,
     useCookie: useCookieMock,
     refreshCookie: refreshCookieMock,
   }),
@@ -83,10 +80,9 @@ describe('request interceptors', () => {
       expect(mockLogger.debug).not.toHaveBeenCalled()
     })
 
-    it('appends client headers in SSR [cookie, user-agent, origin]', async () => {
+    it('appends client headers in SSR [cookie, user-agent]', async () => {
       useSanctumConfigMock.mockReturnValue({
         mode: 'cookie',
-        origin: 'http://custom-origin.dev',
       })
       isServerRuntimeMock.mockReturnValue(true)
       useRequestHeadersMock.mockReturnValue({
@@ -108,8 +104,6 @@ describe('request interceptors', () => {
 
       expect(ctx.options.headers).toStrictEqual(
         new Headers({
-          'Referer': 'http://custom-origin.dev',
-          'Origin': 'http://custom-origin.dev',
           'Cookie': 'random-cookie=value',
           'User-Agent': 'random-user-agent',
         }),
@@ -117,49 +111,9 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).toHaveBeenCalledWith(['cookie', 'user-agent'])
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(mockLogger.debug).toHaveBeenCalledWith(
         '[request] added client headers to server request',
-        ['Referer', 'Origin', 'Cookie', 'User-Agent'],
-      )
-    })
-
-    it('appends request origin if not provided', async () => {
-      useSanctumConfigMock.mockReturnValue({ mode: 'cookie' })
-      isServerRuntimeMock.mockReturnValue(true)
-      useRequestHeadersMock.mockReturnValue({
-        'cookie': 'random-cookie=value',
-        'user-agent': 'random-user-agent',
-      })
-      useRequestURLMock.mockReturnValue({ origin: 'http://custom-origin.dev' })
-
-      const mockApp = createAppMock()
-      const mockLogger = createLoggerMock()
-
-      const ctx = createMock<FetchContext>({
-        options: {
-          method: undefined,
-          headers: new Headers(),
-        },
-      })
-
-      await setStatefulParams(mockApp, ctx, mockLogger)
-
-      expect(ctx.options.headers).toStrictEqual(
-        new Headers({
-          'Referer': 'http://custom-origin.dev',
-          'Origin': 'http://custom-origin.dev',
-          'Cookie': 'random-cookie=value',
-          'User-Agent': 'random-user-agent',
-        }),
-      )
-
-      expect(isServerRuntimeMock).toHaveBeenCalled()
-      expect(useRequestHeadersMock).toHaveBeenCalledWith(['cookie', 'user-agent'])
-      expect(useRequestURLMock).toHaveBeenCalled()
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[request] added client headers to server request',
-        ['Referer', 'Origin', 'Cookie', 'User-Agent'],
+        ['Cookie', 'User-Agent'],
       )
     })
 
@@ -195,7 +149,6 @@ describe('request interceptors', () => {
 
         expect(isServerRuntimeMock).toHaveBeenCalled()
         expect(useRequestHeadersMock).not.toHaveBeenCalled()
-        expect(useRequestURLMock).not.toHaveBeenCalled()
         expect(useCookieMock).toHaveBeenCalledWith(
           'cookie_name',
           { readonly: true, watch: false },
@@ -230,7 +183,6 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).not.toHaveBeenCalled()
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(mockLogger.debug).not.toHaveBeenCalled()
     })
 
@@ -260,7 +212,6 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).not.toHaveBeenCalled()
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(mockLogger.debug).not.toHaveBeenCalled()
     })
 
@@ -303,7 +254,6 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).not.toHaveBeenCalled()
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(useCookieMock).toHaveBeenCalledWith(
         'cookie_name',
         { readonly: true, watch: false },
@@ -348,7 +298,6 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).not.toHaveBeenCalled()
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(useCookieMock).toHaveBeenCalledWith(
         'cookie_name',
         { readonly: true, watch: false },
@@ -386,7 +335,6 @@ describe('request interceptors', () => {
 
       expect(isServerRuntimeMock).toHaveBeenCalled()
       expect(useRequestHeadersMock).not.toHaveBeenCalled()
-      expect(useRequestURLMock).not.toHaveBeenCalled()
       expect(useCookieMock).toHaveBeenCalledWith(
         'cookie_name',
         { readonly: true, watch: false },


### PR DESCRIPTION
**Describe the problem and solution**

Closes #618 .

Extracted logic around `origin` and `referrer` headers into separate interceptor which works regardless of selected mode (`token` or `cookie`).
